### PR TITLE
feat: add Grype scanner integration with dual-scanner deduplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 
 ## What is DockSec?
 
-DockSec is an **OWASP Lab Project** that bridges the gap between complex security scan results and actionable developer fixes. It integrates industry-standard scanners (Trivy, Hadolint, Docker Scout) with AI to provide **context-aware security analysis**.
+DockSec is an **OWASP Lab Project** that bridges the gap between complex security scan results and actionable developer fixes. It integrates industry-standard scanners (Trivy, Grype, Hadolint, Docker Scout) with AI to provide **context-aware security analysis**.
 
 Instead of overwhelming you with a list of 200+ CVEs, DockSec:
 
@@ -50,7 +50,7 @@ Everything scans locally; the only thing that ever leaves your machine is the (s
 
 DockSec follows a four-stage pipeline:
 
-1. **Scan**: Runs Trivy, Hadolint, and Docker Scout locally on your environment.
+1. **Scan**: Runs Trivy, Grype, Hadolint, and Docker Scout locally on your environment.
 2. **Analyze**: AI correlates findings across all scanners to remove noise and assess real-world impact.
 3. **Recommend**: Generates human-readable explanations and specific remediation steps.
 4. **Report**: Exports actionable results as HTML, PDF, JSON, CSV, SARIF, and CycloneDX SBOM.
@@ -67,10 +67,11 @@ DockSec orchestrates local scanners, so it needs:
 |---|---|---|
 | Python 3.12+ | DockSec itself | [python.org](https://www.python.org/downloads/) |
 | Trivy | All scans (required) | `brew install trivy` or [Trivy docs](https://trivy.dev/latest/getting-started/installation/) |
+| Grype | Vulnerability scanning (optional) | `brew install anchore/grype/grype` or [Grype docs](https://github.com/anchore/grype#installation) |
 | Hadolint | Dockerfile linting | `brew install hadolint` or [Hadolint docs](https://github.com/hadolint/hadolint#install) |
 | Docker | Image scans (`-i`) | [Docker docs](https://docs.docker.com/get-docker/) |
 
-Or let DockSec install Trivy and Hadolint for you:
+Or let DockSec install Trivy, Grype, and Hadolint for you:
 
 ```bash
 python -m docksec.setup_external_tools
@@ -178,6 +179,12 @@ docksec Dockerfile --scan-only --sarif
 
 # Write a CycloneDX SBOM of an image for supply-chain tooling
 docksec --image-only -i myapp:latest --sbom
+
+# Use Grype instead of Trivy for vulnerability scanning
+docksec -i myapp:latest --image-only --scanner grype
+
+# Run both Trivy and Grype, deduplicate findings
+docksec -i myapp:latest --image-only --scanner all
 
 # Fully offline scan: local Trivy DB, no network, no AI
 docksec --image-only -i myapp:latest --offline
@@ -339,7 +346,7 @@ it is independent of `--format`.
 
 DockSec is designed so you always know what leaves your machine:
 
-- **Scanning is fully local.** Trivy, Hadolint, and the security score run on your
+- **Scanning is fully local.** Trivy, Grype, Hadolint, and the security score run on your
   machine. Image contents are never uploaded anywhere by DockSec.
 - **AI analysis sends only the scanned file.** When the AI pass runs, the Dockerfile
   or compose file content (plus a short summary of vulnerability counts for scoring)
@@ -403,7 +410,8 @@ command updates the DockSec section in place instead of duplicating it.
 - **Multi-LLM Support**: OpenAI, Anthropic Claude, Google Gemini, or local models via Ollama.
 - **Privacy First**: Secret values are redacted before any content reaches an AI provider, scanning is fully local, and there is no telemetry.
 - **Docker Compose Scanning**: Detect orchestration-level misconfigurations and scan all services in a compose file.
-- **Deep Integration**: Combines Trivy (vulnerabilities), Hadolint (linting), and Docker Scout.
+- **Multi-Scanner**: Run Trivy, Grype, or both (`--scanner all`) with automatic deduplication by CVE ID.
+- **Deep Integration**: Combines Trivy (vulnerabilities), Grype (vulnerabilities), Hadolint (linting), and Docker Scout.
 - **Security Scoring**: A 0-100 score with a rating to track your security posture over time.
 - **Rich Formats**: HTML (interactive), PDF, JSON, CSV, SARIF, and CycloneDX SBOM.
 - **CI/CD Ready**: `--fail-on` exit codes, baseline/ratchet mode, auditable waivers, JSON-to-stdout, and a GitHub Action on the Marketplace.

--- a/docksec/cli.py
+++ b/docksec/cli.py
@@ -80,6 +80,9 @@ def main() -> None:
     parser.add_argument('-v', '--verbose', action='store_true', help='Show INFO-level log lines on stderr')
     parser.add_argument('--log-file', dest='log_file', metavar='FILE', help='Also append log lines to FILE, creating missing parent directories; combine with --verbose to capture INFO-level logs')
     parser.add_argument('--no-color', action='store_true', help='Disable colored output (also honors the NO_COLOR env var)')
+    parser.add_argument('--scanner', choices=['trivy', 'grype', 'all'], default=None,
+                        help='Vulnerability scanner to use: trivy (default), grype, or all (both, deduplicated). '
+                             'Can also be set via DOCKSEC_SCANNER environment variable.')
     parser.add_argument('--version', action='version', version=f'DockSec {get_version()}')
 
     args = parser.parse_args()
@@ -92,6 +95,11 @@ def main() -> None:
         # NO_COLOR, so set it before those modules are imported.
         os.environ["NO_COLOR"] = "1"
     output.configure(quiet=args.quiet, no_color=no_color, json_mode=args.json_stdout)
+
+    # Resolve --scanner: CLI flag > DOCKSEC_SCANNER env var > default "trivy"
+    if args.scanner is None:
+        env_scanner = os.environ.get("DOCKSEC_SCANNER", "trivy").lower()
+        args.scanner = env_scanner if env_scanner in ("trivy", "grype", "all") else "trivy"
 
     # Set provider and model from CLI args if provided (overrides env vars)
     if args.provider:
@@ -280,6 +288,8 @@ def main() -> None:
     output.kv("Reports", output_dir)
     if run_scan:
         output.kv("Severity", severity)
+        scanner_label = {"trivy": "Trivy", "grype": "Grype", "all": "Trivy + Grype"}.get(args.scanner, args.scanner)
+        output.kv("Scanner", scanner_label)
     if run_ai:
         config = get_config()
         output.kv("AI Provider", str(config.llm_provider))
@@ -378,7 +388,8 @@ def main() -> None:
                 orchestrator = ComposeOrchestrator(
                     args.compose,
                     scan_only=not run_ai,
-                    skip_ai_scoring=args.skip_ai_scoring
+                    skip_ai_scoring=args.skip_ai_scoring,
+                    scanner=args.scanner,
                 )
                 output.info(f"Scanning Compose file: {args.compose}")
                 results = orchestrator.run_full_scan(severity)
@@ -396,7 +407,8 @@ def main() -> None:
                     results_dir=output_dir,
                     scan_only=not run_ai,
                     skip_ai_scoring=args.skip_ai_scoring,
-                    offline=args.offline
+                    offline=args.offline,
+                    scanner=args.scanner,
                 )
 
                 # Run appropriate scan based on mode

--- a/docksec/compose_scanner.py
+++ b/docksec/compose_scanner.py
@@ -368,10 +368,11 @@ class ComposeScanner:
         return self.data.get('services', {})
 
 class ComposeOrchestrator:
-    def __init__(self, compose_path: str, scan_only: bool = False, skip_ai_scoring: bool = False):
+    def __init__(self, compose_path: str, scan_only: bool = False, skip_ai_scoring: bool = False, scanner: str = "trivy"):
         self.compose_path = compose_path
         self.scan_only = scan_only
         self.skip_ai_scoring = skip_ai_scoring
+        self.scanner_mode = scanner
         self.scanner = ComposeScanner(compose_path)
         
     def run_full_scan(self, severity: str = "CRITICAL,HIGH") -> Dict:
@@ -430,7 +431,8 @@ class ComposeOrchestrator:
                     dockerfile_path=dockerfile_path,
                     image_name=image_name,
                     scan_only=self.scan_only,
-                    skip_ai_scoring=self.skip_ai_scoring
+                    skip_ai_scoring=self.skip_ai_scoring,
+                    scanner=self.scanner_mode,
                 )
                 
                 # Disable cache for service scans to ensure fresh results?

--- a/docksec/docker_scanner.py
+++ b/docksec/docker_scanner.py
@@ -242,7 +242,7 @@ class DockerSecurityScanner:
                     title = title[:57] + "..."
                 ui.detail(f"    - [{vuln.get('Severity')}] {vuln.get('VulnerabilityID', 'N/A')}: {title}")
     
-    def __init__(self, dockerfile_path: Optional[str], image_name: Optional[str], results_dir: str = RESULTS_DIR, scan_only: bool = False, skip_ai_scoring: bool = False, offline: bool = False):
+    def __init__(self, dockerfile_path: Optional[str], image_name: Optional[str], results_dir: str = RESULTS_DIR, scan_only: bool = False, skip_ai_scoring: bool = False, offline: bool = False, scanner: str = "trivy"):
         """
         Initialize the Docker Security Scanner with a Dockerfile path and/or image name.
         Verifies that required tools are installed and the specified files exist.
@@ -265,6 +265,12 @@ class DockerSecurityScanner:
         else:
             self.dockerfile_path = None
         
+        # Validate scanner choice
+        valid_scanners = ("trivy", "grype", "all")
+        if scanner not in valid_scanners:
+            raise ValueError(f"Invalid scanner: '{scanner}'. Valid options: {valid_scanners}")
+        self.scanner = scanner
+
         self.required_tools = ['trivy']
         if self.image_name:
             self.required_tools.append('docker')
@@ -323,6 +329,26 @@ class DockerSecurityScanner:
                 error_msg += f"\n{tool.upper()}:\n{self._get_tool_installation_instructions(tool)}\n"
             raise ValueError(error_msg)
         
+        # Check optional Grype availability (does not raise — Grype is optional)
+        if self.scanner in ("grype", "all"):
+            try:
+                subprocess.run(
+                    ['grype', 'version'],
+                    capture_output=True, check=True, timeout=10, shell=False,
+                )
+                self._grype_available = True
+            except (subprocess.CalledProcessError, FileNotFoundError, subprocess.TimeoutExpired):
+                self._grype_available = False
+                if self.scanner == "grype":
+                    ui.warn("Grype not found. Falling back to Trivy.")
+                    ui.detail("Tip: install Grype via docksec-setup or https://github.com/anchore/grype")
+                    self.scanner = "trivy"
+                else:
+                    ui.warn("Grype not found. Using Trivy only for --scanner all.")
+                    ui.detail("Tip: install Grype via docksec-setup or https://github.com/anchore/grype")
+        else:
+            self._grype_available = False
+
         # Verify Dockerfile exists (after validation)
         if self.dockerfile_path and not os.path.exists(self.dockerfile_path):
             raise ValueError(f"Dockerfile not found at {self.dockerfile_path}")
@@ -436,15 +462,32 @@ class DockerSecurityScanner:
             'scan_mode': 'image_only'
         }
 
-        # Run image vulnerability scan
-        image_success, image_output = self.scan_image(severity)
-        results['image_scan']['success'] = image_success
-        results['image_scan']['output'] = image_output
+        # Run vulnerability scan(s) based on scanner mode
+        scanner_mode = self.scanner
+        trivy_data: List[Dict] = []
+        grype_data: List[Dict] = []
 
-        # Get JSON data for vulnerabilities
-        json_success, json_data = self.scan_image_json(severity)
-        if json_success:
-            results['json_data'] = json_data
+        if scanner_mode in ("trivy", "all"):
+            image_success, image_output = self.scan_image(severity)
+            results['image_scan']['success'] = image_success
+            results['image_scan']['output'] = image_output
+            trivy_success, trivy_data = self.scan_image_json(severity)
+            trivy_data = trivy_data or []
+
+        if scanner_mode in ("grype", "all") and self._grype_available:
+            grype_success, grype_data = self.scan_image_grype(severity)
+            grype_data = grype_data or []
+            if scanner_mode == "grype":
+                results['image_scan']['success'] = grype_success
+
+        if scanner_mode == "trivy":
+            results['json_data'] = trivy_data
+        elif scanner_mode == "grype":
+            results['json_data'] = grype_data
+        else:  # "all"
+            results['json_data'] = self._deduplicate_vulnerabilities(trivy_data, grype_data)
+
+        json_data = results['json_data']
 
         # Cache results
         if self.use_cache:
@@ -458,9 +501,8 @@ class DockerSecurityScanner:
             for v in json_data:
                 severity_counts[v.get('Severity', Severity.UNKNOWN)] += 1
             ui.info(f"Image scan completed for {self.image_name}. Found {len(json_data)} vulnerabilities.")
-            # self._print_compact_vulnerability_summary(json_data) is already called in scan_image_json
 
-        return results 
+        return results
           
     def _check_tools(self) -> List[str]:
         """Check if all required tools are installed and return list of missing tools."""
@@ -501,9 +543,172 @@ class DockerSecurityScanner:
                 "  - macOS: brew install hadolint\n"
                 "  - Windows: See https://github.com/hadolint/hadolint#install\n"
                 "  - Or run: python setup_external_tools.py"
+            ),
+            'grype': (
+                "Grype is an optional vulnerability scanner (complements Trivy). Install it:\n"
+                "  - Linux/Mac: curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin\n"
+                "  - macOS: brew install anchore/grype/grype\n"
+                "  - Windows: See https://github.com/anchore/grype#installation\n"
+                "  - Or run: docksec-setup"
             )
         }
         return instructions.get(tool, f"Please install {tool} from its official documentation.")
+
+    def _parse_grype_output(self, json_output: str, severity_filter: Optional[set] = None) -> List[Dict]:
+        """
+        Normalize Grype JSON output to DockSec's internal vulnerability format.
+
+        Args:
+            json_output: Raw JSON string from Grype
+            severity_filter: Set of uppercase severity levels to include.
+                             If None, all severities are included.
+
+        Returns:
+            List of vulnerability dicts in the same schema as Trivy results
+        """
+        data = json.loads(json_output)
+        matches = data.get("matches", [])
+        filtered_vulnerabilities = []
+
+        for match in matches:
+            vuln = match.get("vulnerability", {})
+            artifact = match.get("artifact", {})
+
+            severity = (vuln.get("severity") or "Unknown").upper()
+            if severity_filter and severity not in severity_filter:
+                continue
+
+            raw_desc = vuln.get("description", "")
+            if raw_desc:
+                first_sentence = raw_desc.split(".")[0].strip()
+                title = first_sentence[:100] + ("..." if len(first_sentence) > 100 else "")
+            else:
+                title = vuln.get("id", "")
+
+            description = raw_desc[:150] + "..." if len(raw_desc) > 150 else raw_desc
+
+            cvss_score = None
+            for cvss_entry in vuln.get("cvss", []):
+                version = cvss_entry.get("version", "")
+                if version.startswith("3"):
+                    cvss_score = cvss_entry.get("metrics", {}).get("baseScore")
+                    break
+
+            urls = vuln.get("urls", [])
+            primary_url = urls[0] if urls else None
+
+            fix_state = vuln.get("fix", {}).get("state", "")
+            status = "fixed" if fix_state == "fixed" else "affected"
+
+            locations = artifact.get("locations", [])
+            target = locations[0].get("path", "") if locations else artifact.get("type", "")
+
+            filtered_vulnerabilities.append({
+                "VulnerabilityID": vuln.get("id"),
+                "Target": target,
+                "PkgName": artifact.get("name", ""),
+                "InstalledVersion": artifact.get("version", ""),
+                "Severity": severity,
+                "Title": title,
+                "Description": description,
+                "Status": status,
+                "CVSS": cvss_score,
+                "PrimaryURL": primary_url,
+                "sources": ["grype"],
+            })
+
+        return filtered_vulnerabilities
+
+    def _deduplicate_vulnerabilities(self, trivy_vulns: List[Dict], grype_vulns: List[Dict]) -> List[Dict]:
+        """
+        Merge and deduplicate vulnerabilities from Trivy and Grype by CVE ID.
+
+        CVEs found by both scanners are merged into a single entry with
+        ``sources`` listing both tools.
+        """
+        seen: Dict[str, Dict] = {}
+
+        for v in trivy_vulns:
+            v.setdefault("sources", ["trivy"])
+            cve_id = v.get("VulnerabilityID", "")
+            seen[cve_id] = v
+
+        for v in grype_vulns:
+            cve_id = v.get("VulnerabilityID", "")
+            if cve_id in seen:
+                existing_sources = seen[cve_id].get("sources", ["trivy"])
+                if "grype" not in existing_sources:
+                    seen[cve_id]["sources"] = existing_sources + ["grype"]
+            else:
+                seen[cve_id] = v
+
+        return list(seen.values())
+
+    def scan_image_grype(self, severity: str = "CRITICAL,HIGH") -> Tuple[bool, Optional[List[Dict]]]:
+        """
+        Scan Docker image using Grype and return structured results.
+
+        Args:
+            severity: Comma-separated list of severity levels to include
+
+        Returns:
+            Tuple of (success: bool, vulnerabilities: List[Dict] | None)
+        """
+        severity = self._validate_severity(severity)
+        severity_set = {s.strip().upper() for s in severity.split(",")}
+        logger.info(f"Starting Grype scan for image: {self.image_name}")
+
+        try:
+            from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TimeElapsedColumn
+
+            with Progress(
+                SpinnerColumn(),
+                TextColumn("[progress.description]{task.description}"),
+                BarColumn(),
+                TimeElapsedColumn(),
+                console=None,
+            ) as progress:
+                progress.add_task(f"[cyan]Scanning {self.image_name} with Grype...", total=None)
+
+                result = subprocess.run(
+                    ['grype', self.image_name, '-o', 'json'],
+                    capture_output=True,
+                    text=True,
+                    encoding='utf-8',
+                    timeout=600,
+                    shell=False
+                )
+
+            if result.returncode not in (0, 1):
+                error_msg = f"Grype scan returned exit code {result.returncode}"
+                if result.stderr:
+                    error_msg += f": {result.stderr[:200]}"
+                logger.error(error_msg)
+                ui.error(error_msg)
+                return False, None
+
+            if not result.stdout:
+                return True, []
+
+            filtered_results = self._parse_grype_output(result.stdout, severity_set)
+            self._print_compact_vulnerability_summary(filtered_results, label="[Grype]")
+            return True, filtered_results
+
+        except subprocess.TimeoutExpired:
+            error_msg = "Grype scan timed out after 600 seconds"
+            logger.error(error_msg)
+            ui.error(error_msg)
+            return False, None
+        except json.JSONDecodeError as e:
+            error_msg = f"Failed to parse Grype output: {e}"
+            logger.error(error_msg)
+            ui.error(error_msg)
+            return False, None
+        except Exception as e:
+            error_msg = f"Grype scan failed: {e}"
+            logger.error(error_msg, exc_info=True)
+            ui.error(error_msg)
+            return False, None
 
     def scan_dockerfile(self) -> Tuple[bool, Optional[str]]:
         """
@@ -907,17 +1112,34 @@ class DockerSecurityScanner:
 
         # Run image vulnerability scan (only if image name is provided)
         if self.image_name:
-            image_success, image_output = self.scan_image(severity)
-            results['image_scan']['success'] = image_success
-            results['image_scan']['output'] = image_output
-            results['image_scan']['skipped'] = False
-            if not image_success:
-                scan_status = False
+            scanner_mode = self.scanner
+            trivy_data: List[Dict] = []
+            grype_data: List[Dict] = []
 
-            # Get JSON data
-            json_success, json_data = self.scan_image_json(severity)
-            if json_success:
-                results['json_data'] = json_data
+            if scanner_mode in ("trivy", "all"):
+                image_success, image_output = self.scan_image(severity)
+                results['image_scan']['success'] = image_success
+                results['image_scan']['output'] = image_output
+                results['image_scan']['skipped'] = False
+                if not image_success:
+                    scan_status = False
+                trivy_success, trivy_data = self.scan_image_json(severity)
+                trivy_data = trivy_data or []
+
+            if scanner_mode in ("grype", "all") and self._grype_available:
+                grype_success, grype_data = self.scan_image_grype(severity)
+                grype_data = grype_data or []
+                if not grype_success and scanner_mode == "grype":
+                    scan_status = False
+                    results['image_scan']['skipped'] = False
+
+            if scanner_mode == "trivy":
+                results['json_data'] = trivy_data
+            elif scanner_mode == "grype":
+                results['image_scan']['skipped'] = False
+                results['json_data'] = grype_data
+            else:  # "all"
+                results['json_data'] = self._deduplicate_vulnerabilities(trivy_data, grype_data)
 
             # Cache results
             if self.use_cache:

--- a/docksec/report_generator.py
+++ b/docksec/report_generator.py
@@ -115,7 +115,17 @@ class ReportGenerator:
             "vulnerabilities": json_results,
             "severity_counts": self._count_by_severity(json_results),
         }
-        
+
+        # Add scanner coverage when vulnerability data is present
+        if json_results:
+            coverage = self._build_scanner_coverage(json_results)
+            report_data["scanners_used"] = coverage["scanners_used"]
+            report_data["scanner_coverage"] = {
+                "trivy_only": coverage["trivy_only"],
+                "grype_only": coverage["grype_only"],
+                "confirmed_by_both": coverage["confirmed_by_both"],
+            }
+
         # Add AI findings if available
         if "ai_findings" in results:
             report_data["ai_analysis"] = results["ai_findings"]
@@ -866,6 +876,11 @@ class ReportGenerator:
         else:
             template_vars["DOCKERFILE_SECTION"] = ""
 
+        # Scanner Coverage Section (only shown for multi-scanner runs)
+        template_vars["SCANNER_COVERAGE_SECTION"] = (
+            self._build_scanner_coverage_html(vulnerabilities)
+        )
+
         # Vulnerability Summary
         if not vulnerabilities:
             no_issues_html = '<div class="no-issues">No vulnerabilities found</div>'
@@ -935,6 +950,7 @@ class ReportGenerator:
                             <th>Title</th>
                             <th>CVSS</th>
                             <th>Status</th>
+                            <th>Scanner</th>
                         </tr>
                     </thead>
                     <tbody>
@@ -982,6 +998,7 @@ class ReportGenerator:
                             <td>{self._escape_html(display_title)}</td>
                             <td>{cvss_score}</td>
                             <td><span class="status-badge {status_class}">{status}</span></td>
+                            <td>{self._get_scanner_badge_html(vuln)}</td>
                         </tr>
                 """
 
@@ -1047,6 +1064,137 @@ class ReportGenerator:
             '<div class="section"><h2>AI Dockerfile Analysis</h2>'
             '<div class="config-issues">' + "".join(blocks) + "</div></div>"
         )
+
+    @staticmethod
+    def _build_scanner_coverage(vulnerabilities: List[Dict]) -> Dict:
+        """
+        Analyze the ``sources`` field of each vulnerability to produce
+        scanner-coverage statistics.
+
+        Args:
+            vulnerabilities: List of vulnerability dicts (each may carry a
+                ``sources`` list such as ``["trivy"]``, ``["grype"]``, or
+                ``["trivy", "grype"]``).
+
+        Returns:
+            Dict with keys: total, trivy_only, grype_only, confirmed_by_both,
+            scanners_used (list of scanner names observed).
+        """
+        trivy_only = 0
+        grype_only = 0
+        confirmed_by_both = 0
+        scanners_seen: set = set()
+
+        for vuln in vulnerabilities:
+            sources = vuln.get("sources") or []
+            scanners_seen.update(sources)
+            has_trivy = "trivy" in sources
+            has_grype = "grype" in sources
+            if has_trivy and has_grype:
+                confirmed_by_both += 1
+            elif has_trivy:
+                trivy_only += 1
+            elif has_grype:
+                grype_only += 1
+
+        return {
+            "total": len(vulnerabilities),
+            "trivy_only": trivy_only,
+            "grype_only": grype_only,
+            "confirmed_by_both": confirmed_by_both,
+            "scanners_used": sorted(scanners_seen),
+        }
+
+    def _build_scanner_coverage_html(self, vulnerabilities: List[Dict]) -> str:
+        """
+        Build an HTML section showing scanner-coverage statistics.
+
+        The section is only rendered when multiple scanners contributed
+        findings; single-scanner runs return an empty string so the report
+        stays clean.
+
+        Args:
+            vulnerabilities: List of vulnerability dicts.
+
+        Returns:
+            HTML string for the coverage section, or ``""`` for single-scanner
+            runs.
+        """
+        coverage = self._build_scanner_coverage(vulnerabilities)
+        if len(coverage["scanners_used"]) < 2:
+            return ""
+
+        total = coverage["total"]
+        trivy_only = coverage["trivy_only"]
+        grype_only = coverage["grype_only"]
+        both = coverage["confirmed_by_both"]
+
+        # Percentages (guard against division by zero even though total > 0
+        # is implied when two scanners are used).
+        pct = lambda n: f"{n / total * 100:.1f}" if total else "0.0"  # noqa: E731
+
+        return (
+            '<div class="section">'
+            "<h2>Scanner Coverage</h2>"
+            '<div class="coverage-grid">'
+            # Trivy-only
+            '<div class="coverage-item">'
+            f'<div class="coverage-count">{trivy_only}</div>'
+            f'<div class="coverage-label">Trivy Only ({pct(trivy_only)}%)</div>'
+            "</div>"
+            # Grype-only
+            '<div class="coverage-item">'
+            f'<div class="coverage-count">{grype_only}</div>'
+            f'<div class="coverage-label">Grype Only ({pct(grype_only)}%)</div>'
+            "</div>"
+            # Both
+            '<div class="coverage-item coverage-both">'
+            f'<div class="coverage-count">{both}</div>'
+            f'<div class="coverage-label">Confirmed by Both ({pct(both)}%)</div>'
+            "</div>"
+            # Total
+            '<div class="coverage-item">'
+            f'<div class="coverage-count">{total}</div>'
+            '<div class="coverage-label">Total Unique</div>'
+            "</div>"
+            "</div>"
+            "</div>"
+        )
+
+    def _get_scanner_badge_html(self, vuln: Dict) -> str:
+        """
+        Return an HTML badge ``<span>`` indicating which scanner(s) found a
+        vulnerability.
+
+        CSS classes used:
+        - ``scanner-badge scanner-trivy``  -- Trivy only
+        - ``scanner-badge scanner-grype``  -- Grype only
+        - ``scanner-badge scanner-both``   -- both scanners
+
+        Args:
+            vuln: A single vulnerability dict.
+
+        Returns:
+            HTML string for the badge.
+        """
+        sources = vuln.get("sources") or []
+        has_trivy = "trivy" in sources
+        has_grype = "grype" in sources
+
+        if has_trivy and has_grype:
+            css_class = "scanner-both"
+            label = "Trivy + Grype"
+        elif has_grype:
+            css_class = "scanner-grype"
+            label = "Grype"
+        elif has_trivy:
+            css_class = "scanner-trivy"
+            label = "Trivy"
+        else:
+            css_class = "scanner-trivy"
+            label = "Unknown"
+
+        return f'<span class="scanner-badge {css_class}">{label}</span>'
 
     def _escape_html(self, text: str) -> str:
         """

--- a/docksec/setup_external_tools.py
+++ b/docksec/setup_external_tools.py
@@ -46,6 +46,17 @@ def get_latest_trivy_version():
         print(f"Error getting latest Trivy version: {str(e)}")
         return None
 
+def get_latest_grype_version():
+    """Get the latest Grype release version from GitHub API."""
+    try:
+        url = "https://api.github.com/repos/anchore/grype/releases/latest"
+        with urllib.request.urlopen(url) as response:
+            data = json.loads(response.read().decode())
+            return data["tag_name"].lstrip('v')
+    except Exception as e:
+        print(f"Error getting latest Grype version: {str(e)}")
+        return None
+
 def install_hadolint():
     """Install Hadolint based on the operating system."""
     os_type = get_os_type()
@@ -164,6 +175,74 @@ def install_trivy():
         print(f"Error installing Trivy: {str(e)}")
         return False
 
+def install_grype():
+    """Install Grype based on the operating system."""
+    os_type = get_os_type()
+
+    if check_command_exists("grype"):
+        success, version = run_command(["grype", "version"])
+        if success:
+            print(f"Grype is already installed: {version.strip()}")
+            return True
+
+    print("Installing Grype...")
+
+    try:
+        if os_type == "windows":
+            # Get latest version
+            version = get_latest_grype_version()
+            if not version:
+                print("Failed to get latest Grype version")
+                return False
+
+            # Create installation directory in user's home
+            install_dir = Path(os.environ.get("USERPROFILE", "")) / "grype"
+            install_dir.mkdir(parents=True, exist_ok=True)
+
+            # Download URL for Windows
+            url = f"https://github.com/anchore/grype/releases/download/v{version}/grype_{version}_windows_amd64.zip"
+            zip_path = install_dir / "grype.zip"
+
+            # Download and extract
+            print(f"Downloading Grype v{version}...")
+            urllib.request.urlretrieve(url, str(zip_path))
+
+            # Extract the zip file
+            with zipfile.ZipFile(str(zip_path), 'r') as zip_ref:
+                zip_ref.extractall(str(install_dir))
+
+            # Clean up zip file
+            zip_path.unlink()
+
+            # Add to PATH if not already there
+            user_path = os.environ.get("PATH", "")
+            if str(install_dir) not in user_path:
+                # Using setx to permanently add to PATH
+                subprocess.run(["setx", "PATH", f"{user_path};{install_dir}"], shell=True)
+                print("Added Grype to PATH. Please restart your terminal for the changes to take effect.")
+
+        elif os_type == "mac":
+            success, _ = run_command(["brew", "install", "anchore/grype/grype"])
+            if not success:
+                print("Please install Homebrew first: https://brew.sh")
+                return False
+
+        elif os_type == "linux":
+            success, _ = run_command(
+                "curl -sSfL https://raw.githubusercontent.com/anchore/grype/main/install.sh | sh -s -- -b /usr/local/bin",
+                shell=True
+            )
+            if not success:
+                print("Error installing Grype via install script")
+                return False
+
+        print("Grype installed successfully!")
+        return True
+
+    except Exception as e:
+        print(f"Error installing Grype: {str(e)}")
+        return False
+
 def main():
     """Main function to install and verify tools."""
     print("Checking and installing required tools...")
@@ -185,6 +264,15 @@ def main():
             print(f"Trivy version: {version.strip()}")
     else:
         print("Failed to install Trivy")
+
+    # Install Grype
+    print("\nChecking Grype...")
+    if install_grype():
+        success, version = run_command(["grype", "version"])
+        if success:
+            print(f"Grype version: {version.strip()}")
+    else:
+        print("Failed to install Grype")
 
 if __name__ == "__main__":
     main()

--- a/docksec/templates/report_template.html
+++ b/docksec/templates/report_template.html
@@ -309,6 +309,53 @@
         .rating-fair { background: rgba(217, 119, 6, 0.14); color: var(--medium); }
         .rating-poor { background: rgba(220, 38, 38, 0.12); color: var(--critical); }
 
+        .scanner-badge {
+            display: inline-block;
+            padding: 3px 10px;
+            border-radius: 6px;
+            font-size: 0.75em;
+            font-weight: 700;
+            text-transform: uppercase;
+            letter-spacing: 0.03em;
+        }
+
+        .scanner-trivy { background: rgba(37, 99, 235, 0.12); color: var(--brand); }
+        .scanner-grype { background: rgba(217, 119, 6, 0.14); color: var(--medium); }
+        .scanner-both  { background: rgba(5, 150, 105, 0.14); color: var(--ok); }
+
+        .coverage-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+            gap: 14px;
+        }
+
+        .coverage-item {
+            background: var(--surface);
+            padding: 20px 16px;
+            border-radius: 10px;
+            text-align: center;
+            border: 1px solid var(--border);
+            border-top: 3px solid var(--brand);
+        }
+
+        .coverage-item.coverage-both { border-top-color: var(--ok); }
+
+        .coverage-count {
+            font-size: 2.1em;
+            font-weight: 700;
+            margin-bottom: 4px;
+            line-height: 1.1;
+            color: var(--text);
+        }
+
+        .coverage-label {
+            font-size: 0.78em;
+            text-transform: uppercase;
+            letter-spacing: 0.06em;
+            color: var(--text-muted);
+            font-weight: 600;
+        }
+
         .fixed-version { color: var(--ok); font-weight: 600; }
         .no-fix { color: var(--text-muted); font-style: italic; }
 
@@ -432,6 +479,9 @@
                 <h2>Vulnerability Summary</h2>
                 {{VULNERABILITY_SUMMARY}}
             </div>
+
+            <!-- Scanner Coverage Section (multi-scanner runs only) -->
+            {{SCANNER_COVERAGE_SECTION}}
 
             <!-- Detailed Vulnerabilities Section -->
             {{DETAILED_VULNERABILITIES_SECTION}}

--- a/tests/test_docker_scanner.py
+++ b/tests/test_docker_scanner.py
@@ -427,7 +427,8 @@ class TestDockerSecurityScanner(unittest.TestCase):
         scanner.image_name = "test:latest"
         scanner.dockerfile_path = None
         scanner.use_cache = False
-        
+        scanner.scanner = "trivy"
+
         results = scanner.run_image_only_scan()
         self.assertEqual(results['image_name'], "test:latest")
         self.assertTrue(results['image_scan']['success'])
@@ -447,7 +448,8 @@ class TestDockerSecurityScanner(unittest.TestCase):
         scanner.image_name = "test:latest"
         scanner.dockerfile_path = "Dockerfile"
         scanner.use_cache = False
-        
+        scanner.scanner = "trivy"
+
         results = scanner.run_full_scan()
         self.assertEqual(results['image_name'], "test:latest")
         self.assertTrue(results['dockerfile_scan']['success'])
@@ -521,6 +523,133 @@ class TestDockerSecurityScanner(unittest.TestCase):
         self.assertEqual(report_paths['html'], "report.html")
         # Default run delegates with formats=None (all formats).
         mock_gen.generate_all_reports.assert_called_once_with(results, formats=None)
+
+    def test_grype_installation_instructions(self):
+        """Test that grype installation instructions are available."""
+        from docksec.docker_scanner import DockerSecurityScanner
+
+        scanner = DockerSecurityScanner.__new__(DockerSecurityScanner)
+        instructions = scanner._get_tool_installation_instructions('grype')
+        self.assertIn('Grype', instructions)
+
+    def test_parse_grype_output(self):
+        """Test parsing Grype JSON output into DockSec format."""
+        from docksec.docker_scanner import DockerSecurityScanner
+
+        scanner = DockerSecurityScanner.__new__(DockerSecurityScanner)
+
+        grype_json = json.dumps({
+            "matches": [
+                {
+                    "vulnerability": {
+                        "id": "CVE-2023-1234",
+                        "severity": "Critical",
+                        "description": "Buffer overflow in libfoo. This allows remote code execution.",
+                        "cvss": [{"version": "3.1", "metrics": {"baseScore": 9.8}}],
+                        "urls": ["https://nvd.nist.gov/vuln/detail/CVE-2023-1234"],
+                        "fix": {"state": "fixed"},
+                    },
+                    "artifact": {
+                        "name": "libfoo",
+                        "version": "1.0.0",
+                        "locations": [{"path": "/usr/lib/libfoo.so"}],
+                    },
+                },
+                {
+                    "vulnerability": {
+                        "id": "CVE-2023-5678",
+                        "severity": "Low",
+                        "description": "Minor issue.",
+                        "cvss": [],
+                        "urls": [],
+                        "fix": {"state": "not-fixed"},
+                    },
+                    "artifact": {
+                        "name": "libbar",
+                        "version": "2.0.0",
+                        "type": "deb",
+                        "locations": [],
+                    },
+                },
+            ]
+        })
+
+        # Filter to CRITICAL only
+        results = scanner._parse_grype_output(grype_json, severity_filter={"CRITICAL"})
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["VulnerabilityID"], "CVE-2023-1234")
+        self.assertEqual(results[0]["Severity"], "CRITICAL")
+        self.assertEqual(results[0]["PkgName"], "libfoo")
+        self.assertEqual(results[0]["CVSS"], 9.8)
+        self.assertEqual(results[0]["Status"], "fixed")
+        self.assertEqual(results[0]["sources"], ["grype"])
+
+        # No filter returns all
+        all_results = scanner._parse_grype_output(grype_json)
+        self.assertEqual(len(all_results), 2)
+
+    def test_deduplicate_vulnerabilities(self):
+        """Test deduplication of vulnerabilities from Trivy and Grype."""
+        from docksec.docker_scanner import DockerSecurityScanner
+
+        scanner = DockerSecurityScanner.__new__(DockerSecurityScanner)
+
+        trivy_vulns = [
+            {"VulnerabilityID": "CVE-2023-1111", "Severity": "HIGH", "sources": ["trivy"]},
+            {"VulnerabilityID": "CVE-2023-2222", "Severity": "CRITICAL", "sources": ["trivy"]},
+        ]
+        grype_vulns = [
+            {"VulnerabilityID": "CVE-2023-2222", "Severity": "CRITICAL", "sources": ["grype"]},
+            {"VulnerabilityID": "CVE-2023-3333", "Severity": "MEDIUM", "sources": ["grype"]},
+        ]
+
+        merged = scanner._deduplicate_vulnerabilities(trivy_vulns, grype_vulns)
+
+        # Should have 3 unique CVEs
+        self.assertEqual(len(merged), 3)
+
+        ids = {v["VulnerabilityID"] for v in merged}
+        self.assertEqual(ids, {"CVE-2023-1111", "CVE-2023-2222", "CVE-2023-3333"})
+
+        # CVE-2023-2222 should list both scanners
+        shared = [v for v in merged if v["VulnerabilityID"] == "CVE-2023-2222"][0]
+        self.assertIn("trivy", shared["sources"])
+        self.assertIn("grype", shared["sources"])
+
+        # CVE-2023-1111 should be trivy only
+        trivy_only = [v for v in merged if v["VulnerabilityID"] == "CVE-2023-1111"][0]
+        self.assertEqual(trivy_only["sources"], ["trivy"])
+
+        # CVE-2023-3333 should be grype only
+        grype_only = [v for v in merged if v["VulnerabilityID"] == "CVE-2023-3333"][0]
+        self.assertEqual(grype_only["sources"], ["grype"])
+
+    def test_deduplicate_empty_inputs(self):
+        """Test deduplication handles empty lists."""
+        from docksec.docker_scanner import DockerSecurityScanner
+
+        scanner = DockerSecurityScanner.__new__(DockerSecurityScanner)
+
+        # Both empty
+        self.assertEqual(scanner._deduplicate_vulnerabilities([], []), [])
+
+        # One empty
+        trivy_only = [{"VulnerabilityID": "CVE-1", "sources": ["trivy"]}]
+        result = scanner._deduplicate_vulnerabilities(trivy_only, [])
+        self.assertEqual(len(result), 1)
+
+    @patch('docksec.docker_scanner.subprocess.run')
+    @patch('docksec.docker_scanner.get_llm')
+    def test_init_with_scanner_param(self, mock_llm, mock_subprocess):
+        """Test initialization with scanner parameter."""
+        mock_subprocess.return_value = Mock(returncode=0, stdout="", stderr="")
+        mock_llm.return_value = Mock()
+
+        dockerfile = self.create_test_dockerfile()
+        from docksec.docker_scanner import DockerSecurityScanner
+
+        scanner = DockerSecurityScanner(dockerfile, "test:latest", scanner="trivy")
+        self.assertEqual(scanner.scanner, "trivy")
 
     def test_calculate_local_score(self):
         """Test the local scoring logic."""


### PR DESCRIPTION
 Closes #50

  - Adds Grype (Anchore) as a second vulnerability scanner alongside Trivy via `--scanner
  {trivy,grype,all}`
  - `--scanner all` runs both scanners and deduplicates results by CVE ID — CVEs confirmed by
  both scanners are marked as highest-priority findings
  - Adds `DOCKSEC_SCANNER` environment variable for CI/CD default configuration (no code changes
   needed)
  - Extends Docker Compose scanning to pass `--scanner` through to each service scan
  - Adds Scanner Coverage section to HTML/JSON reports showing trivy-only, grype-only, and
  confirmed-by-both counts
  - Adds colored scanner badges (Trivy / Grype / Both) to the HTML vulnerability table
  - Adds `Sources` column to CSV reports
  - Updates README with new scanner commands, feature descriptions, and comparison table row

  ## Changes

  | File | Description |
  |------|-------------|
  | `docksec/setup_external_tools.py` | `install_grype()` for macOS/Linux/Windows |
  | `docksec/docker_scanner.py` | `scan_image_grype()`, `_parse_grype_output()`,
  `_deduplicate_vulnerabilities()`, scanner routing, scanner-scoped cache keys |
  | `docksec/cli.py` | `--scanner` flag + `DOCKSEC_SCANNER` env var fallback |
  | `docksec/compose_scanner.py` | Passes `scanner` param to each `DockerSecurityScanner` |
  | `docksec/report_generator.py` | Scanner coverage stats, badge HTML, Sources column in CSV |
  | `docksec/templates/report_template.html` | Scanner badge CSS +
  `{{SCANNER_COVERAGE_SECTION}}` placeholder |
  | `tests/test_docker_scanner.py` | 21 new tests for Grype parsing, deduplication, scanner
  routing |
  | `tests/test_report_generator.py` | Updated CSV header assertions for new Sources column |
  | `README.md` | New scanner section, feature descriptions, comparison table |