### PR TITLE
fix(compose): surface per-service scan failures in user-facing summary

### DIFF
--- a/docksec/cli.py
+++ b/docksec/cli.py
@@ -767,6 +767,9 @@ def _print_json_results(results, scanner, report_paths):
     if results.get("suppressed_count"):
         payload["scan_info"]["suppressed_count"] = results["suppressed_count"]
         payload["scan_info"]["ignore_file"] = results.get("ignore_file")
+    if results.get("failed_services"):
+        payload["scan_info"]["failed_services"] = results["failed_services"]
+        payload["scan_info"]["total_services"] = results.get("total_services")
     if "ai_findings" in results:
         payload["ai_analysis"] = results["ai_findings"]
     if report_paths:
@@ -790,6 +793,23 @@ def _render_scan_summary(output, args, scanner, results, report_paths,
     if report_paths:
         output.report_results(report_paths, scanner.RESULTS_DIR)
     output.next_command(_suggest_next_command(args, results, run_ai, run_compose_analysis))
+
+
+def _failed_service_names(failed_services):
+    """Return the distinct service names in ``failed_services``, in order.
+
+    A service that fails both its Dockerfile and its image scan is recorded
+    once per scan, so de-duplicate before counting.
+    """
+    names = []
+    for entry in failed_services or []:
+        name = entry.get("service") if isinstance(entry, dict) else entry
+        if not name:
+            continue
+        name = str(name)
+        if name not in names:
+            names.append(name)
+    return names
 
 
 def _quick_take_lines(results, counts, run_ai):
@@ -824,6 +844,17 @@ def _quick_take_lines(results, counts, run_ai):
     suppressed = results.get("suppressed_count")
     if suppressed:
         lines.append(f"{suppressed} triaged finding(s) suppressed via ignore file")
+
+    # A compose service whose scan failed still leaves the run with a score, so
+    # say so here: otherwise the summary reads as if every service was covered.
+    failed_names = _failed_service_names(results.get("failed_services"))
+    if failed_names:
+        names = ", ".join(failed_names)
+        total = results.get("total_services")
+        if isinstance(total, int) and total > 0:
+            lines.append(f"{len(failed_names)} of {total} services could not be scanned: {names}")
+        else:
+            lines.append(f"{len(failed_names)} service(s) could not be scanned: {names}")
 
     if not run_ai and not results.get("ai_findings"):
         if results.get("scan_mode") == "image_only":

--- a/docksec/compose_scanner.py
+++ b/docksec/compose_scanner.py
@@ -384,7 +384,8 @@ class ComposeOrchestrator:
                 'image_name': "N/A",
                 'dockerfile_path': self.compose_path,
                 'scan_mode': 'compose',
-                'failed_services': []
+                'failed_services': [],
+                'total_services': 0
             }
             
         compose_findings = self.scanner.scan()
@@ -516,5 +517,6 @@ class ComposeOrchestrator:
             'image_name': "Multiple Services",
             'dockerfile_path': self.compose_path,
             'scan_mode': 'compose',
-            'failed_services': failed_services
+            'failed_services': failed_services,
+            'total_services': len(services)
         }

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -415,6 +415,68 @@ class TestCLIHelpers(unittest.TestCase):
         lines = _quick_take_lines(results, counts, run_ai=True)
         self.assertTrue(any("4 triaged finding(s) suppressed" in line for line in lines))
 
+    def test_quick_take_reports_failed_compose_services(self):
+        from docksec.cli import _quick_take_lines
+
+        results = {
+            "dockerfile_scan": {"skipped": True},
+            "scan_mode": "compose",
+            "total_services": 3,
+            "failed_services": [
+                {"service": "web", "reason": "Image scan failed"},
+                {"service": "db", "reason": "Image scan failed"},
+            ],
+        }
+        counts = {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0}
+        lines = _quick_take_lines(results, counts, run_ai=True)
+        self.assertTrue(
+            any("2 of 3 services could not be scanned: web, db" in line for line in lines)
+        )
+
+    def test_quick_take_counts_a_doubly_failed_service_once(self):
+        from docksec.cli import _quick_take_lines
+
+        results = {
+            "dockerfile_scan": {"skipped": True},
+            "scan_mode": "compose",
+            "total_services": 2,
+            "failed_services": [
+                {"service": "web", "reason": "Dockerfile scan failed"},
+                {"service": "web", "reason": "Image scan failed"},
+            ],
+        }
+        counts = {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0}
+        lines = _quick_take_lines(results, counts, run_ai=True)
+        self.assertTrue(
+            any("1 of 2 services could not be scanned: web" in line for line in lines)
+        )
+
+    def test_quick_take_reports_failures_without_a_service_total(self):
+        from docksec.cli import _quick_take_lines
+
+        results = {
+            "dockerfile_scan": {"skipped": True},
+            "failed_services": [{"service": "web", "reason": "boom"}],
+        }
+        counts = {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0}
+        lines = _quick_take_lines(results, counts, run_ai=True)
+        self.assertTrue(
+            any("1 service(s) could not be scanned: web" in line for line in lines)
+        )
+
+    def test_quick_take_stays_silent_when_every_service_scanned(self):
+        from docksec.cli import _quick_take_lines
+
+        results = {
+            "dockerfile_scan": {"skipped": True},
+            "scan_mode": "compose",
+            "total_services": 3,
+            "failed_services": [],
+        }
+        counts = {"CRITICAL": 0, "HIGH": 0, "MEDIUM": 0, "LOW": 0}
+        lines = _quick_take_lines(results, counts, run_ai=True)
+        self.assertFalse(any("could not be scanned" in line for line in lines))
+
     def test_suggest_next_command_recommends_image_scan(self):
         from docksec.cli import _suggest_next_command
 

--- a/tests/test_compose_scanner.py
+++ b/tests/test_compose_scanner.py
@@ -174,3 +174,46 @@ def test_compose_orchestrator_offline(valid_compose_file, mocker):
     assert results['dockerfile_scan']['success'] is True
     assert results['image_scan']['success'] is True 
     assert results["failed_services"] == []
+
+def test_compose_orchestrator_reports_total_services(valid_compose_file, mocker):
+    mock_scanner = mocker.patch('docksec.compose_scanner.DockerSecurityScanner')
+    mock_instance = mock_scanner.return_value
+    mock_instance.run_image_only_scan.return_value = {
+        'image_scan': {'success': True, 'output': 'Mock output'},
+        'json_data': []
+    }
+
+    orchestrator = ComposeOrchestrator(valid_compose_file, scan_only=True)
+    results = orchestrator.run_full_scan()
+
+    # The quick take renders "N of M services could not be scanned", so the
+    # denominator has to travel with failed_services.
+    assert results['total_services'] == 2
+    assert results['failed_services'] == []
+
+
+def test_compose_orchestrator_records_failed_services(valid_compose_file, mocker):
+    mock_scanner = mocker.patch('docksec.compose_scanner.DockerSecurityScanner')
+    mock_instance = mock_scanner.return_value
+    mock_instance.run_image_only_scan.return_value = {
+        'image_scan': {'success': False, 'output': 'image not found locally'},
+        'json_data': []
+    }
+
+    orchestrator = ComposeOrchestrator(valid_compose_file, scan_only=True)
+    results = orchestrator.run_full_scan()
+
+    assert results['total_services'] == 2
+    failed = {entry['service'] for entry in results['failed_services']}
+    assert failed == {'web', 'db'}
+
+
+def test_compose_orchestrator_unparseable_file_reports_zero_services(tmp_path):
+    bad = tmp_path / "docker-compose.yml"
+    bad.write_text("services: [this is not a mapping")
+
+    orchestrator = ComposeOrchestrator(str(bad), scan_only=True)
+    results = orchestrator.run_full_scan()
+
+    assert results['failed_services'] == []
+    assert results['total_services'] == 0


### PR DESCRIPTION
# Pull Request

## Description

Rebased onto current `main` and rewritten now that #161 has merged.

#161 added `failed_services` tracking inside `ComposeOrchestrator.run_full_scan`, which covers the first two acceptance criteria of #131. Nothing reads that field back out, so the third one is still open: a compose run where some services could not be scanned still prints a Quick take and a security score as if every service had been covered. That is the misleading behaviour #131 was filed about.

This PR adds only the missing user-facing half, on top of #161:

1. `compose_scanner.py` carries `total_services` alongside `failed_services`, so the summary has a denominator.
2. `cli.py` prints one Quick take line — `N of M services could not be scanned: <names>` — and includes `failed_services` / `total_services` in `--json` output.
3. A service that fails both its Dockerfile scan and its image scan is appended twice by `run_full_scan`, so names are de-duplicated before counting.

No change to exit codes, scoring, or scan behaviour — this is purely the visibility fix #131 asked for.

Before (current `main`, 2 of 3 services unscannable):

```
Quick take
  - 16 security findings (0 critical, 0 high)
  - Run without --scan-only to add AI-powered explanations and fixes
```

After:

```
Quick take
  - 16 security findings (0 critical, 0 high)
  - 2 of 3 services could not be scanned: web, db
  - Run without --scan-only to add AI-powered explanations and fixes
```

The per-service `reason` strings are available in `--json` under `scan_info.failed_services`; I kept them out of the one-line Quick take because they vary per service. Happy to inline the reason if you would rather match the issue's example wording exactly.

Closes #131

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

- [x] Unit tests
- [x] Manual testing

Added 7 tests: 4 in `tests/test_cli.py` covering the summary line, the de-duplication, the no-total fallback, and silence when nothing failed; 3 in `tests/test_compose_scanner.py` covering `total_services`, populated `failed_services`, and the unparseable-compose path.

- `pytest tests/` — 254 passed, 2 skipped. The 2 failures in `tests/test_utils.py` on my machine are the optional `docksec[ai]` extras not being installed, and reproduce unchanged on `main`.
- `ruff check .` — all checks passed.
- Ran the real orchestrator and renderer against a 3-service compose file with 2 unresolvable images to produce the output above.

**Test Configuration:**
- Python version: 3.12.13
- Operating System: Windows 11
- DockSec version: `main` @ 77c0cd1

## Checklist

- [x] Code follows the style guidelines of this project
- [x] Self-review completed
- [x] Hard-to-understand areas are commented
- [x] No new warnings or errors introduced
- [x] Tests added that prove the fix works
- [x] All existing tests pass
- [x] Spelling checked

## Related Issues / PRs

- Closes #131
- Builds on #161

---

By submitting this pull request, I confirm that my contribution is made under the terms of the MIT license.
