### PR TITLE
feat: add repo-level .docksec.yml configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -194,6 +194,8 @@ SESSION_SUMMARY.md
 CURSOR_CONFIGURATION.md
 
 # Internal/maintainer documentation (not for public repository)
+docs/promptfoo-benchmark-review.md
+ROADMAP.md
 
 # Claude Code project instructions (local only, not for public repository)
 CLAUDE.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 All notable changes to DockSec are documented in this file.
 
-## Unreleased
+## 2026.8.19
+
+Adds a committed configuration file so a team's scan policy lives in the repository
+instead of in per-developer flags and environment variables.
 
 ### Added
 
@@ -26,6 +29,19 @@ All notable changes to DockSec are documented in this file.
 A config file that exists but is invalid (unknown key, bad severity value) exits `2`
 with the offending key named, rather than warning and continuing - a broken policy
 file must not silently scan under rules the team did not commit.
+
+### Changed
+
+- `--offline`, `--no-cache`, `--no-redact`, and `--skip-ai-scoring` now default to
+  `None` rather than `False` internally, so an absent flag is distinguishable from an
+  explicit `false` and no longer overrides a config file value. Behavior is unchanged
+  when no config file is present.
+
+### Fixed
+
+- Lint rules are now pinned in `pyproject.toml` (`[tool.ruff.lint] select`) instead of
+  inheriting ruff's defaults. Ruff 0.16 enabled several new rule groups by default,
+  which failed CI on every pull request without any code change.
 
 ## 2026.7.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to DockSec are documented in this file.
 
+## Unreleased
+
+### Added
+
+- Repo-level configuration file (`.docksec.yml`): commit scan policy - severity,
+  `fail_on`, report formats, output directory, provider/model, waiver and baseline
+  paths, and disabled rules - to the repository instead of passing per-developer
+  flags. Discovery starts in the working directory and walks up to the repository
+  root, so a monorepo subdirectory inherits the policy committed at the top level.
+- Precedence is CLI flag > environment variable > `.docksec.yml` > built-in default,
+  so committed policy never overrides an explicit flag or an exported variable.
+- `--config FILE` to use a specific config file, and `--no-config` to ignore config
+  discovery entirely for reproducible CI runs.
+- `rules.disabled` in the config file switches individual rules off before scoring,
+  reports, `--json`, and the `--fail-on` gate. The waiver file remains the right tool
+  for individual findings, since its entries carry a reason and an expiry date.
+- `--print-config-schema` emits the JSON Schema for the config file. The schema is
+  committed at `docs/docksec-config-schema.json`, and the `# yaml-language-server:`
+  comment in the example config enables editor autocomplete and inline validation.
+- An annotated example config at `examples/.docksec.yml`.
+
+A config file that exists but is invalid (unknown key, bad severity value) exits `2`
+with the offending key named, rather than warning and continuing - a broken policy
+file must not silently scan under rules the team did not commit.
+
 ## 2026.7.5
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -204,6 +204,92 @@ docksec Dockerfile --no-color                           # also honors NO_COLOR
 
 ---
 
+## Configuration file
+
+Commit a `.docksec.yml` at the root of your repository and the whole team - and
+every CI job - scans under the same policy, instead of each developer passing
+their own flags.
+
+```yaml
+# yaml-language-server: $schema=https://owasp.org/DockSec/docksec-config-schema.json
+severity: CRITICAL,HIGH
+fail_on: HIGH
+formats: [json, html]
+output_dir: ./security-reports
+
+rules:
+  disabled:
+    - compose-missing-healthcheck
+```
+
+Every setting is optional; anything you leave out falls back to the environment
+variable and then to the built-in default. A full annotated example is in
+[`examples/.docksec.yml`](examples/.docksec.yml).
+
+### Precedence
+
+Highest priority first:
+
+```
+CLI flag  >  environment variable  >  .docksec.yml  >  built-in default
+```
+
+So a committed `severity: LOW` is still overridden by `--severity CRITICAL` on
+the command line, and by `DOCKSEC_DEFAULT_SEVERITY` in the environment.
+
+### Discovery
+
+DockSec looks for `.docksec.yml` (or `.docksec.yaml`) in the working directory
+and then walks up to the repository root, so a service in a monorepo
+subdirectory inherits the policy committed at the top level. The search stops at
+the directory containing `.git`, so it never picks up a file from outside the
+repository.
+
+- `--config FILE` uses a specific file instead of searching.
+- `--no-config` ignores any config file, for reproducible CI runs.
+
+The config file in force is shown in the scan banner, so it is always clear
+which policy was applied.
+
+### Settings
+
+| Setting | Equivalent flag | Notes |
+| --- | --- | --- |
+| `severity` | `--severity` | Severity levels for the image scan |
+| `fail_on` | `--fail-on` | CI gate threshold |
+| `formats` | `--format` | List form: `[json, html]` |
+| `output_dir` | `--output-dir` | Report destination |
+| `provider` | `--provider` | `openai`, `anthropic`, `google`, `ollama` |
+| `model` | `--model` | Model name for the provider |
+| `offline` | `--offline` | No network; skips AI and Docker Scout |
+| `skip_ai_scoring` | `--skip-ai-scoring` | Local scoring only |
+| `no_redact` | `--no-redact` | Do not mask secrets before the AI call |
+| `no_cache` | `--no-cache` | Bypass the scan cache |
+| `ignore_file` | `--ignore-file` | Waiver file path |
+| `baseline` | `--baseline` | Baseline file path |
+| `rules.disabled` | - | Rule IDs to switch off entirely |
+
+An invalid config file - an unknown key, a bad severity - is a hard error that
+exits `2` rather than a warning, so a broken policy file can never cause a scan
+to run under rules the team did not commit.
+
+### Editor autocomplete
+
+The `# yaml-language-server:` comment on the first line gives completion and
+inline validation in VS Code and JetBrains editors. The schema is published at
+[`docs/docksec-config-schema.json`](docs/docksec-config-schema.json) and can be
+regenerated with `docksec --print-config-schema`.
+
+### Disabling rules
+
+`rules.disabled` switches a check off entirely, everywhere - it is removed
+before scoring, reports, `--json`, and the `--fail-on` gate. Use it for checks
+that do not apply to your environment. For individual findings your team has
+triaged and accepted, prefer the [waiver file](#ignoring-findings-waivers),
+whose entries carry a reason and an expiry date and so stay auditable.
+
+---
+
 ## CI/CD Integration
 
 ### Exit codes

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ API keys, private key blocks) are masked automatically. See
 
 ```yaml
 - name: Run DockSec AI Scanner
-  uses: OWASP/DockSec@v2026.7.5
+  uses: OWASP/DockSec@v2026.8.19
   with:
     dockerfile: 'Dockerfile'
     openai_api_key: ${{ secrets.OPENAI_API_KEY }}
@@ -329,7 +329,7 @@ directly on pull requests and in the Security tab:
 
 ```yaml
 - name: Run DockSec
-  uses: OWASP/DockSec@v2026.7.5
+  uses: OWASP/DockSec@v2026.8.19
   with:
     dockerfile: 'Dockerfile'
     sarif: 'true'

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,9 +13,6 @@ moves to the [CHANGELOG](CHANGELOG.md).
 - **Registry / remote image scanning.** Scan images in a registry (Artifactory, Harbor,
   ECR, Docker Hub) without a local Docker daemon, using Trivy's remote scanning and the
   standard registry auth environment variables. Unblocks daemonless CI runners.
-- **Repo-level configuration file.** A committed `.docksec.yml` for severity, fail-on
-  threshold, report formats, output directory, disabled rules, and provider settings,
-  so a team's policy lives in the repo instead of per-developer flags.
 - **Dockerfile lint findings as first-class findings.** Parse Hadolint output into
   structured findings with mapped severities so they participate in `--fail-on`,
   `--json`, SARIF, and the reports like image vulnerabilities already do.
@@ -46,6 +43,8 @@ moves to the [CHANGELOG](CHANGELOG.md).
 
 ## Recently shipped
 
-See the [CHANGELOG](CHANGELOG.md). Highlights from 2026.7.4/2026.7.5: secret redaction
-before AI analysis, auditable waiver files, digest-keyed scan caching with TTL, a slim
-scan-only install, tuned compose rules, and an overhauled HTML report.
+See the [CHANGELOG](CHANGELOG.md). Most recently: a repo-level `.docksec.yml`
+configuration file with a published JSON Schema, so a team's scan policy lives in the
+repository instead of in per-developer flags. Highlights from 2026.7.4/2026.7.5: secret
+redaction before AI analysis, auditable waiver files, digest-keyed scan caching with TTL,
+a slim scan-only install, tuned compose rules, and an overhauled HTML report.

--- a/docksec/cli.py
+++ b/docksec/cli.py
@@ -31,6 +31,125 @@ def get_version() -> str:
 
     return "unknown"
 
+def _load_project_config(args, output):
+    """Discover, load, and apply the repo-level config file.
+
+    Returns (file_config, config_path). The path is None when no file was used.
+
+    Precedence is enforced by only filling in settings the user left unset: an
+    explicit CLI flag is never overwritten, and env-var-backed settings are
+    applied by writing the environment variable only when it is not already set,
+    so `LLM_PROVIDER=x docksec ...` still beats a committed provider.
+
+    A config file that exists but is invalid exits 2. Unlike the ignore file,
+    where a bad entry is skipped with a warning, a broken policy file must stop
+    the run rather than silently scan under rules the team did not commit.
+    """
+    from docksec.project_config import (
+        ConfigFileError,
+        DocksecFileConfig,
+        find_config_file,
+        load_config_file,
+    )
+
+    # get_config() calls load_dotenv() lazily, which would otherwise populate
+    # the environment *after* the checks below and let the config file win over
+    # a .env entry. Load it up front so env-over-file precedence holds.
+    try:
+        from dotenv import load_dotenv
+        load_dotenv()
+    except ImportError:  # python-dotenv is a core dep; tolerate its absence
+        pass
+
+    if args.no_config:
+        return DocksecFileConfig(), None
+
+    if args.config_file:
+        # An explicitly named file that is missing is a usage error; a merely
+        # absent auto-discovered file is not.
+        if not os.path.isfile(args.config_file):
+            output.error(f"Config file not found: {args.config_file}")
+            sys.exit(2)
+        config_path = args.config_file
+    else:
+        config_path = find_config_file()
+        if not config_path:
+            return DocksecFileConfig(), None
+
+    try:
+        file_config, warnings = load_config_file(config_path)
+    except ConfigFileError as exc:
+        output.error(str(exc))
+        sys.exit(2)
+
+    for warning in warnings:
+        output.warn(warning)
+
+    # Settings that reach the rest of the CLI as attributes on `args`.
+    # Severity resolves through get_config().default_severity, which cannot
+    # distinguish "DOCKSEC_DEFAULT_SEVERITY was set" from "built-in default".
+    # Setting the env var here (only when absent) keeps env-over-file ordering
+    # without changing how the rest of the CLI reads the value.
+    if file_config.severity and not os.getenv("DOCKSEC_DEFAULT_SEVERITY"):
+        os.environ["DOCKSEC_DEFAULT_SEVERITY"] = file_config.severity
+
+    for attr, value in (
+        ("fail_on", file_config.fail_on),
+        ("output_dir", file_config.output_dir),
+        ("ignore_file", file_config.ignore_file),
+        ("baseline", file_config.baseline),
+        ("offline", file_config.offline),
+        ("skip_ai_scoring", file_config.skip_ai_scoring),
+        ("no_redact", file_config.no_redact),
+        ("no_cache", file_config.no_cache),
+    ):
+        if value is not None and getattr(args, attr, None) is None:
+            setattr(args, attr, value)
+
+    # --format is parsed from a comma-separated string; the file supplies a list.
+    if file_config.formats is not None and args.format is None:
+        args.format = ",".join(file_config.formats)
+
+    # Provider and model travel via environment variables. Only set them when
+    # the env var is absent, so an explicitly exported value still wins.
+    if file_config.provider and not os.getenv("LLM_PROVIDER"):
+        os.environ["LLM_PROVIDER"] = file_config.provider
+    if file_config.model and not os.getenv("LLM_MODEL"):
+        os.environ["LLM_MODEL"] = file_config.model
+
+    return file_config, config_path
+
+
+def _apply_disabled_rules(results, disabled_rules, output):
+    """Drop findings whose rule ID is disabled in the config file.
+
+    Applied alongside the ignore-file waivers, before scoring, reports, JSON
+    output, and the --fail-on gate, so a disabled rule is invisible everywhere.
+    Matching is case-insensitive on VulnerabilityID, consistent with waivers.
+    """
+    if not disabled_rules or not results.get("json_data"):
+        return 0
+
+    disabled = {rule.lower() for rule in disabled_rules}
+    kept = []
+    removed = 0
+    for finding in results["json_data"]:
+        rule_id = str(finding.get("VulnerabilityID", "")).lower()
+        if rule_id in disabled:
+            removed += 1
+        else:
+            kept.append(finding)
+
+    if removed:
+        results["json_data"] = kept
+        results["disabled_rule_count"] = removed
+        output.info(
+            f"Suppressed {removed} finding(s) from {len(disabled)} disabled rule(s) "
+            f"in the config file"
+        )
+    return removed
+
+
 def main() -> None:
     """
     Main entry point for the DockSec CLI tool.
@@ -62,7 +181,7 @@ def main() -> None:
                        help='LLM provider to use (default: openai, can also set LLM_PROVIDER env var)')
     parser.add_argument('--model', help='Model name to use (e.g., gpt-4o, claude-haiku-4-5, gemini-1.5-pro, llama3.1)')
     parser.add_argument('--compact-output', action='store_true', help='Use compact output format (less verbose)')
-    parser.add_argument('--skip-ai-scoring', action='store_true', help='Skip AI-based security scoring (use local scoring only)')
+    parser.add_argument('--skip-ai-scoring', action='store_true', default=None, help='Skip AI-based security scoring (use local scoring only)')
     parser.add_argument('--severity', help='Comma-separated severity levels to scan for (default: CRITICAL,HIGH; or set DOCKSEC_DEFAULT_SEVERITY)')
     parser.add_argument('--fail-on', dest='fail_on', metavar='SEVERITY', help='Exit with code 1 if any finding is at or above this severity (CRITICAL, HIGH, MEDIUM, or LOW)')
     parser.add_argument('--format', dest='format', help='Comma-separated report formats to write: json, csv, pdf, html (default: all)')
@@ -70,12 +189,15 @@ def main() -> None:
     parser.add_argument('--json', dest='json_stdout', action='store_true', help='Print scan results as JSON to stdout (no report files unless --format is also given)')
     parser.add_argument('--sarif', dest='sarif', action='store_true', help='Write a SARIF 2.1.0 report for GitHub Code Scanning and other SARIF-compatible tools')
     parser.add_argument('--sbom', dest='sbom', action='store_true', help='Write a CycloneDX SBOM (.cdx.json) of the scanned image for supply-chain tooling (requires an image)')
-    parser.add_argument('--offline', dest='offline', action='store_true', help='Run without network access: use the local Trivy DB (no DB update) and skip AI analysis')
-    parser.add_argument('--no-redact', dest='no_redact', action='store_true', help='Do not mask secret-looking values before sending file content to the AI provider')
-    parser.add_argument('--no-cache', dest='no_cache', action='store_true', help='Bypass the scan results cache and force a fresh scan')
+    parser.add_argument('--offline', dest='offline', action='store_true', default=None, help='Run without network access: use the local Trivy DB (no DB update) and skip AI analysis')
+    parser.add_argument('--no-redact', dest='no_redact', action='store_true', default=None, help='Do not mask secret-looking values before sending file content to the AI provider')
+    parser.add_argument('--no-cache', dest='no_cache', action='store_true', default=None, help='Bypass the scan results cache and force a fresh scan')
     parser.add_argument('--ignore-file', dest='ignore_file', metavar='FILE', help='Path to an ignore file listing findings to suppress (default: .docksec-ignore.yml in the current directory, if present)')
     parser.add_argument('--baseline', dest='baseline', metavar='FILE', help='Path to a baseline file; with --fail-on, only findings not present in the baseline trigger the gate')
     parser.add_argument('--update-baseline', dest='update_baseline', action='store_true', help='Write the current scan findings to --baseline instead of gating against it')
+    parser.add_argument('--config', dest='config_file', metavar='FILE', help='Path to a DockSec config file (default: nearest .docksec.yml, searching up to the repository root)')
+    parser.add_argument('--no-config', dest='no_config', action='store_true', help='Ignore any .docksec.yml and use only flags, environment variables, and defaults')
+    parser.add_argument('--print-config-schema', dest='print_config_schema', action='store_true', help='Print the JSON Schema for .docksec.yml to stdout and exit')
     parser.add_argument('--quiet', action='store_true', help='Reduce output to warnings, errors, and the result summary')
     parser.add_argument('-v', '--verbose', action='store_true', help='Show INFO-level log lines on stderr')
     parser.add_argument('--log-file', dest='log_file', metavar='FILE', help='Also append log lines to FILE, creating missing parent directories; combine with --verbose to capture INFO-level logs')
@@ -92,6 +214,21 @@ def main() -> None:
         # NO_COLOR, so set it before those modules are imported.
         os.environ["NO_COLOR"] = "1"
     output.configure(quiet=args.quiet, no_color=no_color, json_mode=args.json_stdout)
+
+    # --print-config-schema is a utility action: emit the schema and exit before
+    # any input validation, so it works from any directory with no arguments.
+    if args.print_config_schema:
+        import json as _json
+        from docksec.project_config import config_json_schema
+        print(_json.dumps(config_json_schema(), indent=2))
+        return
+
+    # Repo-level config file (.docksec.yml). Values here sit below CLI flags and
+    # environment variables: a flag always wins, an env var wins over the file,
+    # and the file wins over the built-in default. Applied before anything reads
+    # the resolved settings below.
+    file_config, config_path = _load_project_config(args, output)
+    disabled_rules = [rule.strip() for rule in file_config.rules.disabled if rule.strip()]
 
     # Set provider and model from CLI args if provided (overrides env vars)
     if args.provider:
@@ -277,6 +414,10 @@ def main() -> None:
     from docksec.enums import LLMProvider
 
     output.banner(get_version(), mode_desc)
+    if config_path:
+        # Surface which committed policy is in force; a silently-applied config
+        # file is a support burden when a scan behaves unexpectedly.
+        output.kv("Config", os.path.relpath(config_path))
     output.kv("Reports", output_dir)
     if run_scan:
         output.kv("Severity", severity)
@@ -430,6 +571,11 @@ def main() -> None:
                     output.info(
                         f"{suppressed_count} finding(s) suppressed by ignore file {ignore_path}"
                     )
+
+            # Rules disabled in the config file are dropped before scoring, so a
+            # rule a team has switched off cannot influence the score, reports,
+            # --json, or the --fail-on gate.
+            _apply_disabled_rules(results, disabled_rules, output)
 
             # Calculate security score
             scanner.analysis_score = scanner.get_security_score(results)

--- a/docksec/project_config.py
+++ b/docksec/project_config.py
@@ -45,7 +45,6 @@ wrong severity while the team believes their committed policy is in force.
 """
 
 import os
-from typing import Dict, List, Optional, Tuple
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
 
@@ -70,7 +69,7 @@ class RulesConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    disabled: List[str] = Field(
+    disabled: list[str] = Field(
         default_factory=list,
         description="Rule IDs to disable entirely (compose rule IDs or vulnerability IDs).",
     )
@@ -87,51 +86,51 @@ class DocksecFileConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    severity: Optional[str] = Field(
+    severity: str | None = Field(
         default=None,
         description="Comma-separated severity levels to scan for, e.g. 'CRITICAL,HIGH'.",
     )
-    fail_on: Optional[str] = Field(
+    fail_on: str | None = Field(
         default=None,
         description="Exit 1 if any finding is at or above this severity.",
     )
-    formats: Optional[List[str]] = Field(
+    formats: list[str] | None = Field(
         default=None,
         description="Report formats to write. Any of: json, csv, pdf, html.",
     )
-    output_dir: Optional[str] = Field(
+    output_dir: str | None = Field(
         default=None,
         description="Directory to write reports to.",
     )
-    provider: Optional[str] = Field(
+    provider: str | None = Field(
         default=None,
         description="LLM provider for the AI analysis pass.",
     )
-    model: Optional[str] = Field(
+    model: str | None = Field(
         default=None,
         description="Model name for the configured provider.",
     )
-    offline: Optional[bool] = Field(
+    offline: bool | None = Field(
         default=None,
         description="Run without network access; skips the AI pass and Docker Scout.",
     )
-    skip_ai_scoring: Optional[bool] = Field(
+    skip_ai_scoring: bool | None = Field(
         default=None,
         description="Use local scoring only, without an LLM scoring call.",
     )
-    no_redact: Optional[bool] = Field(
+    no_redact: bool | None = Field(
         default=None,
         description="Do not mask secret-looking values before the AI call.",
     )
-    no_cache: Optional[bool] = Field(
+    no_cache: bool | None = Field(
         default=None,
         description="Bypass the scan results cache.",
     )
-    ignore_file: Optional[str] = Field(
+    ignore_file: str | None = Field(
         default=None,
         description="Path to a waiver file listing findings to suppress.",
     )
-    baseline: Optional[str] = Field(
+    baseline: str | None = Field(
         default=None,
         description="Path to a baseline file for ratchet mode.",
     )
@@ -142,7 +141,7 @@ class DocksecFileConfig(BaseModel):
 
     @field_validator("severity")
     @classmethod
-    def _check_severity(cls, value: Optional[str]) -> Optional[str]:
+    def _check_severity(cls, value: str | None) -> str | None:
         if value is None:
             return None
         levels = [item.strip().upper() for item in value.split(",") if item.strip()]
@@ -156,7 +155,7 @@ class DocksecFileConfig(BaseModel):
 
     @field_validator("fail_on")
     @classmethod
-    def _check_fail_on(cls, value: Optional[str]) -> Optional[str]:
+    def _check_fail_on(cls, value: str | None) -> str | None:
         if value is None:
             return None
         level = value.strip().upper()
@@ -169,7 +168,7 @@ class DocksecFileConfig(BaseModel):
 
     @field_validator("formats")
     @classmethod
-    def _check_formats(cls, value: Optional[List[str]]) -> Optional[List[str]]:
+    def _check_formats(cls, value: list[str] | None) -> list[str] | None:
         if value is None:
             return None
         requested = [item.strip().lower() for item in value if str(item).strip()]
@@ -184,7 +183,7 @@ class DocksecFileConfig(BaseModel):
 
     @field_validator("provider")
     @classmethod
-    def _check_provider(cls, value: Optional[str]) -> Optional[str]:
+    def _check_provider(cls, value: str | None) -> str | None:
         if value is None:
             return None
         provider = value.strip().lower()
@@ -200,7 +199,7 @@ class ConfigFileError(Exception):
     """Raised when a config file exists but cannot be used as written."""
 
 
-def find_config_file(start_dir: Optional[str] = None) -> Optional[str]:
+def find_config_file(start_dir: str | None = None) -> str | None:
     """Find the nearest .docksec.yml, walking up toward the repository root.
 
     Searching upward means a monorepo subdirectory inherits the policy committed
@@ -226,7 +225,7 @@ def find_config_file(start_dir: Optional[str] = None) -> Optional[str]:
         current = parent
 
 
-def load_config_file(path: str) -> Tuple[DocksecFileConfig, List[str]]:
+def load_config_file(path: str) -> tuple[DocksecFileConfig, list[str]]:
     """Load and validate a config file.
 
     Returns ``(config, warnings)``. Raises :class:`ConfigFileError` when the
@@ -236,17 +235,20 @@ def load_config_file(path: str) -> Tuple[DocksecFileConfig, List[str]]:
     """
     from ruamel.yaml import YAML
 
-    warnings: List[str] = []
+    warnings: list[str] = []
 
     try:
         with open(path, "r", encoding="utf-8") as handle:
             data = YAML(typ="safe").load(handle)
     except FileNotFoundError:
-        raise ConfigFileError(f"Config file not found: {path}")
+        raise ConfigFileError(f"Config file not found: {path}") from None
     except OSError as exc:
-        raise ConfigFileError(f"Could not read config file {path}: {exc}")
+        raise ConfigFileError(f"Could not read config file {path}: {exc}") from exc
     except Exception as exc:
-        raise ConfigFileError(f"Could not parse config file {path}: {exc}")
+        # ruamel raises several unrelated parser/scanner/composer error types for
+        # malformed YAML; all mean the same thing to the user, so they collapse
+        # into one message.
+        raise ConfigFileError(f"Could not parse config file {path}: {exc}") from exc
 
     # An empty file is valid and means "no overrides".
     if data is None:
@@ -279,7 +281,7 @@ def _format_validation_error(path: str, exc: ValidationError) -> str:
     return "\n".join(lines)
 
 
-def config_json_schema() -> Dict:
+def config_json_schema() -> dict:
     """Return the JSON Schema for .docksec.yml.
 
     Exported by ``docksec --print-config-schema`` and committed to

--- a/docksec/project_config.py
+++ b/docksec/project_config.py
@@ -1,0 +1,297 @@
+"""Repo-level configuration file (.docksec.yml).
+
+DockSec has three configuration layers, split by lifetime and ownership:
+
+- ``config.py``          - static paths, prompt templates, and helpers.
+- ``config_manager.py``  - the process/environment layer (env vars, API keys,
+                           timeouts), exposed via ``get_config()``.
+- ``project_config.py``  - this module: the committed, repo-level policy file a
+                           team checks into source control.
+
+The file exists so a team's scan policy (severity threshold, CI gate, disabled
+rules, report formats) lives in the repository next to the Dockerfiles it
+governs, instead of being re-typed as flags by every developer and every CI job.
+
+Resolution order, highest priority first:
+
+    CLI flag  >  environment variable  >  .docksec.yml  >  built-in default
+
+Discovery walks up from the working directory to the repository root (a
+directory containing ``.git``) so that a monorepo subdirectory inherits the
+policy committed at the top level. ``--config`` names a file explicitly and
+``--no-config`` disables discovery entirely.
+
+File format::
+
+    # yaml-language-server: $schema=https://owasp.org/DockSec/docksec-config-schema.json
+    severity: CRITICAL,HIGH
+    fail_on: HIGH
+    formats: [json, html]
+    output_dir: ./security-reports
+    provider: anthropic
+    model: claude-haiku-4-5
+    offline: false
+    ignore_file: .docksec-ignore.yml
+    baseline: .docksec-baseline.json
+    rules:
+      disabled:
+        - compose-missing-healthcheck
+        - compose-no-resource-limits
+
+Unlike the ignore file - whose malformed entries are skipped with a warning
+because suppression is advisory - a malformed config file is a hard error that
+exits 2. Silently ignoring a broken policy file would mean scanning with the
+wrong severity while the team believes their committed policy is in force.
+"""
+
+import os
+from typing import Dict, List, Optional, Tuple
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+from docksec.enums import LLMProvider, Severity
+
+CONFIG_FILENAMES = (".docksec.yml", ".docksec.yaml")
+
+SCHEMA_URL = "https://owasp.org/DockSec/docksec-config-schema.json"
+
+VALID_FORMATS = ("json", "csv", "pdf", "html")
+
+
+class RulesConfig(BaseModel):
+    """Per-rule controls.
+
+    ``disabled`` lists rule IDs (compose rule IDs such as
+    ``compose-missing-healthcheck``, or vulnerability IDs) that should be
+    dropped from the results before scoring, reporting, and the --fail-on gate.
+    This is the blunt, permanent instrument; ``.docksec-ignore.yml`` remains the
+    right tool for auditable, per-finding waivers with a reason and an expiry.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    disabled: List[str] = Field(
+        default_factory=list,
+        description="Rule IDs to disable entirely (compose rule IDs or vulnerability IDs).",
+    )
+
+
+class DocksecFileConfig(BaseModel):
+    """Schema for .docksec.yml.
+
+    Every field is optional. An unset field means "do not override" - it falls
+    through to the environment variable, then to the built-in default. This is
+    why booleans are ``Optional[bool]`` rather than defaulting to False: a
+    missing key and an explicit ``false`` must remain distinguishable.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    severity: Optional[str] = Field(
+        default=None,
+        description="Comma-separated severity levels to scan for, e.g. 'CRITICAL,HIGH'.",
+    )
+    fail_on: Optional[str] = Field(
+        default=None,
+        description="Exit 1 if any finding is at or above this severity.",
+    )
+    formats: Optional[List[str]] = Field(
+        default=None,
+        description="Report formats to write. Any of: json, csv, pdf, html.",
+    )
+    output_dir: Optional[str] = Field(
+        default=None,
+        description="Directory to write reports to.",
+    )
+    provider: Optional[str] = Field(
+        default=None,
+        description="LLM provider for the AI analysis pass.",
+    )
+    model: Optional[str] = Field(
+        default=None,
+        description="Model name for the configured provider.",
+    )
+    offline: Optional[bool] = Field(
+        default=None,
+        description="Run without network access; skips the AI pass and Docker Scout.",
+    )
+    skip_ai_scoring: Optional[bool] = Field(
+        default=None,
+        description="Use local scoring only, without an LLM scoring call.",
+    )
+    no_redact: Optional[bool] = Field(
+        default=None,
+        description="Do not mask secret-looking values before the AI call.",
+    )
+    no_cache: Optional[bool] = Field(
+        default=None,
+        description="Bypass the scan results cache.",
+    )
+    ignore_file: Optional[str] = Field(
+        default=None,
+        description="Path to a waiver file listing findings to suppress.",
+    )
+    baseline: Optional[str] = Field(
+        default=None,
+        description="Path to a baseline file for ratchet mode.",
+    )
+    rules: RulesConfig = Field(
+        default_factory=RulesConfig,
+        description="Per-rule controls.",
+    )
+
+    @field_validator("severity")
+    @classmethod
+    def _check_severity(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        levels = [item.strip().upper() for item in value.split(",") if item.strip()]
+        invalid = [item for item in levels if item not in Severity.values()]
+        if not levels or invalid:
+            raise ValueError(
+                f"invalid severity {value!r}; valid levels are "
+                f"{', '.join(Severity.values())}"
+            )
+        return ",".join(levels)
+
+    @field_validator("fail_on")
+    @classmethod
+    def _check_fail_on(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        level = value.strip().upper()
+        if level not in Severity.gate_levels():
+            raise ValueError(
+                f"invalid fail_on {value!r}; choose one of "
+                f"{', '.join(Severity.gate_levels())}"
+            )
+        return level
+
+    @field_validator("formats")
+    @classmethod
+    def _check_formats(cls, value: Optional[List[str]]) -> Optional[List[str]]:
+        if value is None:
+            return None
+        requested = [item.strip().lower() for item in value if str(item).strip()]
+        invalid = [item for item in requested if item not in VALID_FORMATS]
+        if not requested or invalid:
+            raise ValueError(
+                f"invalid formats {value!r}; valid formats are "
+                f"{', '.join(VALID_FORMATS)}"
+            )
+        # Normalize to the canonical order the CLI uses, dropping duplicates.
+        return [fmt for fmt in VALID_FORMATS if fmt in requested]
+
+    @field_validator("provider")
+    @classmethod
+    def _check_provider(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        provider = value.strip().lower()
+        if provider not in LLMProvider.values():
+            raise ValueError(
+                f"invalid provider {value!r}; valid providers are "
+                f"{', '.join(LLMProvider.values())}"
+            )
+        return provider
+
+
+class ConfigFileError(Exception):
+    """Raised when a config file exists but cannot be used as written."""
+
+
+def find_config_file(start_dir: Optional[str] = None) -> Optional[str]:
+    """Find the nearest .docksec.yml, walking up toward the repository root.
+
+    Searching upward means a monorepo subdirectory inherits the policy committed
+    at the repository root. The walk stops at the directory containing ``.git``
+    (inclusive) so discovery never escapes the repository and picks up an
+    unrelated file from a parent checkout or the user's home directory.
+    """
+    current = os.path.abspath(start_dir or os.getcwd())
+
+    while True:
+        for filename in CONFIG_FILENAMES:
+            candidate = os.path.join(current, filename)
+            if os.path.isfile(candidate):
+                return candidate
+
+        # Stop after checking the repository root itself.
+        if os.path.isdir(os.path.join(current, ".git")):
+            return None
+
+        parent = os.path.dirname(current)
+        if parent == current:  # filesystem root
+            return None
+        current = parent
+
+
+def load_config_file(path: str) -> Tuple[DocksecFileConfig, List[str]]:
+    """Load and validate a config file.
+
+    Returns ``(config, warnings)``. Raises :class:`ConfigFileError` when the
+    file cannot be read, is not valid YAML, is not a mapping, or fails schema
+    validation - a broken policy file must stop the run rather than silently
+    scan under different rules than the team committed.
+    """
+    from ruamel.yaml import YAML
+
+    warnings: List[str] = []
+
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            data = YAML(typ="safe").load(handle)
+    except FileNotFoundError:
+        raise ConfigFileError(f"Config file not found: {path}")
+    except OSError as exc:
+        raise ConfigFileError(f"Could not read config file {path}: {exc}")
+    except Exception as exc:
+        raise ConfigFileError(f"Could not parse config file {path}: {exc}")
+
+    # An empty file is valid and means "no overrides".
+    if data is None:
+        return DocksecFileConfig(), warnings
+
+    if not isinstance(data, dict):
+        raise ConfigFileError(
+            f"Config file {path} must contain a mapping of settings at the top level"
+        )
+
+    try:
+        config = DocksecFileConfig(**data)
+    except ValidationError as exc:
+        raise ConfigFileError(_format_validation_error(path, exc))
+
+    return config, warnings
+
+
+def _format_validation_error(path: str, exc: ValidationError) -> str:
+    """Render a Pydantic error as an actionable, key-by-key CLI message."""
+    lines = [f"Invalid config file {path}:"]
+    for error in exc.errors():
+        location = ".".join(str(part) for part in error["loc"]) or "(top level)"
+        message = error.get("msg", "invalid value")
+        # Pydantic prefixes custom ValueError messages; keep the message clean.
+        message = message.removeprefix("Value error, ")
+        if error.get("type") == "extra_forbidden":
+            message = "unknown setting"
+        lines.append(f"  {location}: {message}")
+    return "\n".join(lines)
+
+
+def config_json_schema() -> Dict:
+    """Return the JSON Schema for .docksec.yml.
+
+    Exported by ``docksec --print-config-schema`` and committed to
+    ``docs/docksec-config-schema.json`` so editors can offer completion and
+    inline validation via the yaml-language-server schema comment.
+    """
+    schema = DocksecFileConfig.model_json_schema()
+    schema["$schema"] = "http://json-schema.org/draft-07/schema#"
+    schema["$id"] = SCHEMA_URL
+    schema["title"] = "DockSec configuration"
+    schema["description"] = (
+        "Repo-level configuration for DockSec (.docksec.yml). "
+        "CLI flags and environment variables override these settings."
+    )
+    return schema

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -5,6 +5,25 @@ All notable changes to DockSec will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2026.8.19] - 2026-08-19
+
+### Added
+
+- **Repo-level configuration file (`.docksec.yml`)**: a committed policy file for severity, `fail_on`, report formats, output directory, provider/model, waiver and baseline paths, and disabled rules, so a team's scan policy lives in the repository instead of in per-developer flags and environment variables. Discovery starts in the working directory and walks up to the repository root (stopping at the directory containing `.git`), so a service in a monorepo subdirectory inherits the policy committed at the top level. Precedence is CLI flag > environment variable > `.docksec.yml` > built-in default, so committed policy never overrides an explicit flag or an exported variable. The config file in force is shown in the scan banner.
+- **`--config FILE` and `--no-config`**: use a specific config file, or skip discovery entirely for reproducible CI runs.
+- **Per-rule disabling (`rules.disabled`)**: switches individual rules off before scoring, reports, `--json`, and the `--fail-on` gate, so a disabled rule cannot influence the security score. Matching is case-insensitive on the rule ID. The waiver file (`.docksec-ignore.yml`) remains the right tool for individual triaged findings, since its entries carry a reason and an expiry date.
+- **`--print-config-schema`**: emits a JSON Schema for the config file, committed at `docs/docksec-config-schema.json`. The `# yaml-language-server:` comment in the example config enables autocomplete and inline validation in VS Code and JetBrains editors.
+- **Annotated example config** at `examples/.docksec.yml`.
+
+### Changed
+
+- `--offline`, `--no-cache`, `--no-redact`, and `--skip-ai-scoring` now default to `None` rather than `False` internally, so an absent flag is distinguishable from an explicit `false` and no longer overrides a value set in the config file. Behavior is unchanged when no config file is present.
+
+### Fixed
+
+- **Invalid config files fail loudly**: a config file that exists but cannot be used as written (unknown key, invalid severity or provider value, malformed YAML) exits `2` with the offending key and file path named, rather than warning and continuing. This is deliberately stricter than the ignore file, where a malformed entry is skipped with a warning: a broken policy file must not silently scan under rules the team did not commit.
+- **Lint rule set pinned**: `[tool.ruff.lint] select` in `pyproject.toml` now fixes the enabled rules instead of inheriting ruff's defaults, which change between releases. Ruff 0.16 enabled several new rule groups by default and failed CI on every pull request without any code change.
+
 ## [Unreleased]
 
 ### Added

--- a/docs/docksec-config-schema.json
+++ b/docs/docksec-config-schema.json
@@ -1,0 +1,191 @@
+{
+  "$defs": {
+    "RulesConfig": {
+      "additionalProperties": false,
+      "description": "Per-rule controls.\n\n``disabled`` lists rule IDs (compose rule IDs such as\n``compose-missing-healthcheck``, or vulnerability IDs) that should be\ndropped from the results before scoring, reporting, and the --fail-on gate.\nThis is the blunt, permanent instrument; ``.docksec-ignore.yml`` remains the\nright tool for auditable, per-finding waivers with a reason and an expiry.",
+      "properties": {
+        "disabled": {
+          "description": "Rule IDs to disable entirely (compose rule IDs or vulnerability IDs).",
+          "items": {
+            "type": "string"
+          },
+          "title": "Disabled",
+          "type": "array"
+        }
+      },
+      "title": "RulesConfig",
+      "type": "object"
+    }
+  },
+  "additionalProperties": false,
+  "description": "Repo-level configuration for DockSec (.docksec.yml). CLI flags and environment variables override these settings.",
+  "properties": {
+    "severity": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Comma-separated severity levels to scan for, e.g. 'CRITICAL,HIGH'.",
+      "title": "Severity"
+    },
+    "fail_on": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Exit 1 if any finding is at or above this severity.",
+      "title": "Fail On"
+    },
+    "formats": {
+      "anyOf": [
+        {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Report formats to write. Any of: json, csv, pdf, html.",
+      "title": "Formats"
+    },
+    "output_dir": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Directory to write reports to.",
+      "title": "Output Dir"
+    },
+    "provider": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "LLM provider for the AI analysis pass.",
+      "title": "Provider"
+    },
+    "model": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Model name for the configured provider.",
+      "title": "Model"
+    },
+    "offline": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Run without network access; skips the AI pass and Docker Scout.",
+      "title": "Offline"
+    },
+    "skip_ai_scoring": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Use local scoring only, without an LLM scoring call.",
+      "title": "Skip Ai Scoring"
+    },
+    "no_redact": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Do not mask secret-looking values before the AI call.",
+      "title": "No Redact"
+    },
+    "no_cache": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Bypass the scan results cache.",
+      "title": "No Cache"
+    },
+    "ignore_file": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Path to a waiver file listing findings to suppress.",
+      "title": "Ignore File"
+    },
+    "baseline": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Path to a baseline file for ratchet mode.",
+      "title": "Baseline"
+    },
+    "rules": {
+      "$ref": "#/$defs/RulesConfig",
+      "description": "Per-rule controls."
+    }
+  },
+  "title": "DockSec configuration",
+  "type": "object",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://owasp.org/DockSec/docksec-config-schema.json"
+}

--- a/examples/.docksec.yml
+++ b/examples/.docksec.yml
@@ -1,0 +1,65 @@
+# yaml-language-server: $schema=https://owasp.org/DockSec/docksec-config-schema.json
+#
+# DockSec repo-level configuration.
+#
+# Commit this file at the root of your repository so the whole team - and CI -
+# scans under the same policy. Every setting is optional; anything you leave out
+# falls back to the environment variable, then to the built-in default.
+#
+# Precedence, highest first:
+#   CLI flag  >  environment variable  >  this file  >  default
+#
+# The schema comment on the first line gives you completion and inline
+# validation in VS Code and JetBrains editors.
+
+# Severity levels included in the image vulnerability scan.
+# Valid: CRITICAL, HIGH, MEDIUM, LOW, UNKNOWN
+severity: CRITICAL,HIGH
+
+# Fail the build (exit 1) when a finding at or above this level is present.
+# Valid: CRITICAL, HIGH, MEDIUM, LOW
+fail_on: HIGH
+
+# Report formats to write. Any of: json, csv, pdf, html
+formats:
+  - json
+  - html
+
+# Where reports are written.
+output_dir: ./security-reports
+
+# LLM provider and model for the AI analysis pass.
+# Valid providers: openai, anthropic, google, ollama
+# Use ollama to keep analysis entirely on your own machine.
+# provider: anthropic
+# model: claude-haiku-4-5
+
+# Run with no network access: use the local Trivy database and skip both the
+# AI pass and Docker Scout.
+# offline: false
+
+# Score locally instead of asking the model for a score.
+# skip_ai_scoring: false
+
+# Send file content to the AI provider without masking secret-looking values.
+# Leave this off unless you have a specific reason.
+# no_redact: false
+
+# Bypass the scan results cache on every run.
+# no_cache: false
+
+# Waiver file: individual findings your team has triaged and accepted, each
+# with a reason and an optional expiry date.
+# ignore_file: .docksec-ignore.yml
+
+# Baseline file for ratchet mode: with fail_on set, only findings introduced
+# after the baseline was captured trip the gate.
+# baseline: .docksec-baseline.json
+
+# Rules to switch off entirely. Use this for checks that do not apply to your
+# environment; prefer the waiver file above for individual findings you have
+# accepted, since those carry a reason and an expiry.
+# rules:
+#   disabled:
+#     - compose-missing-healthcheck
+#     - compose-no-resource-limits

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,18 @@
 requires = ["setuptools>=82.0.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool.ruff]
+target-version = "py312"
+
+[tool.ruff.lint]
+# Pin the rule set explicitly rather than inheriting ruff's defaults, which
+# change between releases: ruff 0.16 enabled several new rule groups by default
+# and turned every previously-green CI run red without a code change. These are
+# ruff's documented defaults (pyflakes plus the core pycodestyle checks).
+# Additional groups can be adopted deliberately, one at a time, alongside the
+# cleanup they require.
+select = ["E4", "E7", "E9", "F"]
+
 [tool.black]
 line-length = 88
 target-version = ['py312']

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 setup(
     name="docksec",
-    version="2026.7.5",
+    version="2026.8.19",
     description="AI-Powered Docker Security Analyzer",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -2,10 +2,12 @@
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 
 import pytest
+from pydantic import ValidationError
 
 from docksec.project_config import (
     ConfigFileError,
@@ -19,6 +21,17 @@ from docksec.project_config import (
 def write(path, text):
     path.write_text(text, encoding="utf-8")
     return str(path)
+
+
+# The end-to-end tests below drive the real CLI, which refuses to start when its
+# external scanners are missing. Not every environment installs them (the
+# coverage workflow, for instance, does not), so those tests skip rather than
+# fail there. The config-file logic itself is covered without them by
+# TestMergeIntoArgs and the schema/discovery tests.
+requires_scan_tools = pytest.mark.skipif(
+    not (shutil.which("trivy") and shutil.which("hadolint")),
+    reason="requires trivy and hadolint on PATH",
+)
 
 
 class TestSchemaValidation:
@@ -60,17 +73,17 @@ class TestSchemaValidation:
         ],
     )
     def test_invalid_values_are_rejected(self, kwargs):
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             DocksecFileConfig(**kwargs)
 
     def test_unknown_key_is_rejected(self):
         """extra=forbid turns a typo into an error instead of a silently
         ignored setting."""
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             DocksecFileConfig(severty="HIGH")
 
     def test_unknown_nested_rules_key_is_rejected(self):
-        with pytest.raises(Exception):
+        with pytest.raises(ValidationError):
             DocksecFileConfig(rules={"disabeld": ["x"]})
 
 
@@ -195,11 +208,11 @@ class TestMergeIntoArgs:
     def blank_args(**overrides):
         import argparse
 
-        defaults = dict(
-            no_config=False, config_file=None, severity=None, fail_on=None,
-            output_dir=None, ignore_file=None, baseline=None, offline=None,
-            skip_ai_scoring=None, no_redact=None, no_cache=None, format=None,
-        )
+        defaults = {
+            "no_config": False, "config_file": None, "severity": None, "fail_on": None,
+            "output_dir": None, "ignore_file": None, "baseline": None, "offline": None,
+            "skip_ai_scoring": None, "no_redact": None, "no_cache": None, "format": None,
+        }
         defaults.update(overrides)
         return argparse.Namespace(**defaults)
 
@@ -294,6 +307,7 @@ class TestCliIntegration:
             text=True,
             env=full_env,
             timeout=120,
+            check=False,  # these tests assert on non-zero exit codes
         )
 
     @pytest.fixture
@@ -349,6 +363,7 @@ class TestCliIntegration:
         assert result.returncode == 0
         assert json.loads(result.stdout)["properties"]["severity"]
 
+    @requires_scan_tools
     def test_disabled_rules_are_dropped_everywhere(self, project):
         """A disabled rule must not reach --json, and by extension not the
         score, the reports, or the --fail-on gate."""
@@ -379,6 +394,7 @@ class TestCliIntegration:
         assert "compose-no-resource-limits" not in ids_after
         assert ids_after < ids_before
 
+    @requires_scan_tools
     def test_disabled_rule_matching_is_case_insensitive(self, project):
         compose = project / "docker-compose.yml"
         compose.write_text(

--- a/tests/test_project_config.py
+++ b/tests/test_project_config.py
@@ -1,0 +1,393 @@
+"""Tests for the repo-level config file (.docksec.yml)."""
+
+import json
+import os
+import subprocess
+import sys
+
+import pytest
+
+from docksec.project_config import (
+    ConfigFileError,
+    DocksecFileConfig,
+    config_json_schema,
+    find_config_file,
+    load_config_file,
+)
+
+
+def write(path, text):
+    path.write_text(text, encoding="utf-8")
+    return str(path)
+
+
+class TestSchemaValidation:
+    def test_empty_config_leaves_everything_unset(self, tmp_path):
+        config, warnings = load_config_file(write(tmp_path / ".docksec.yml", ""))
+        assert config.severity is None
+        assert config.fail_on is None
+        assert config.offline is None
+        assert config.rules.disabled == []
+        assert warnings == []
+
+    def test_unset_boolean_is_none_not_false(self):
+        """An absent key must stay distinguishable from an explicit false, or the
+        config file would clobber flags it never mentioned."""
+        assert DocksecFileConfig().offline is None
+        assert DocksecFileConfig(offline=False).offline is False
+
+    def test_severity_is_normalized(self):
+        assert DocksecFileConfig(severity=" high , critical ").severity == "HIGH,CRITICAL"
+
+    def test_fail_on_is_normalized(self):
+        assert DocksecFileConfig(fail_on="high").fail_on == "HIGH"
+
+    def test_formats_normalized_to_canonical_order_without_duplicates(self):
+        assert DocksecFileConfig(formats=["html", "json", "html"]).formats == ["json", "html"]
+
+    def test_provider_is_lowercased(self):
+        assert DocksecFileConfig(provider="ANTHROPIC").provider == "anthropic"
+
+    @pytest.mark.parametrize(
+        "kwargs",
+        [
+            {"severity": "NOPE"},
+            {"severity": ""},
+            {"fail_on": "SEVERE"},
+            {"formats": ["json", "xml"]},
+            {"formats": []},
+            {"provider": "cohere"},
+        ],
+    )
+    def test_invalid_values_are_rejected(self, kwargs):
+        with pytest.raises(Exception):
+            DocksecFileConfig(**kwargs)
+
+    def test_unknown_key_is_rejected(self):
+        """extra=forbid turns a typo into an error instead of a silently
+        ignored setting."""
+        with pytest.raises(Exception):
+            DocksecFileConfig(severty="HIGH")
+
+    def test_unknown_nested_rules_key_is_rejected(self):
+        with pytest.raises(Exception):
+            DocksecFileConfig(rules={"disabeld": ["x"]})
+
+
+class TestLoading:
+    def test_loads_a_full_config(self, tmp_path):
+        path = write(
+            tmp_path / ".docksec.yml",
+            "severity: MEDIUM,HIGH\n"
+            "fail_on: HIGH\n"
+            "formats: [json, html]\n"
+            "output_dir: ./reports\n"
+            "provider: anthropic\n"
+            "model: claude-haiku-4-5\n"
+            "offline: true\n"
+            "rules:\n"
+            "  disabled:\n"
+            "    - compose-no-resource-limits\n",
+        )
+        config, warnings = load_config_file(path)
+        assert config.severity == "MEDIUM,HIGH"
+        assert config.fail_on == "HIGH"
+        assert config.formats == ["json", "html"]
+        assert config.output_dir == "./reports"
+        assert config.provider == "anthropic"
+        assert config.offline is True
+        assert config.rules.disabled == ["compose-no-resource-limits"]
+        assert warnings == []
+
+    def test_missing_file_raises(self, tmp_path):
+        with pytest.raises(ConfigFileError, match="not found"):
+            load_config_file(str(tmp_path / "absent.yml"))
+
+    def test_malformed_yaml_raises(self, tmp_path):
+        path = write(tmp_path / ".docksec.yml", "severity: [unclosed\n")
+        with pytest.raises(ConfigFileError, match="Could not parse"):
+            load_config_file(path)
+
+    def test_non_mapping_raises(self, tmp_path):
+        path = write(tmp_path / ".docksec.yml", "- a\n- b\n")
+        with pytest.raises(ConfigFileError, match="must contain a mapping"):
+            load_config_file(path)
+
+    def test_error_message_names_the_offending_key(self, tmp_path):
+        path = write(tmp_path / ".docksec.yml", "severty: HIGH\nfail_on: NOPE\n")
+        with pytest.raises(ConfigFileError) as exc:
+            load_config_file(path)
+        message = str(exc.value)
+        assert "severty: unknown setting" in message
+        assert "fail_on" in message
+        assert path in message
+
+
+class TestDiscovery:
+    def test_finds_config_in_current_directory(self, tmp_path):
+        path = write(tmp_path / ".docksec.yml", "severity: HIGH\n")
+        assert find_config_file(str(tmp_path)) == path
+
+    def test_accepts_the_yaml_extension(self, tmp_path):
+        path = write(tmp_path / ".docksec.yaml", "severity: HIGH\n")
+        assert find_config_file(str(tmp_path)) == path
+
+    def test_walks_up_to_the_repository_root(self, tmp_path):
+        """A monorepo subdirectory inherits the policy committed at the root."""
+        (tmp_path / ".git").mkdir()
+        path = write(tmp_path / ".docksec.yml", "severity: HIGH\n")
+        deep = tmp_path / "services" / "api"
+        deep.mkdir(parents=True)
+        assert find_config_file(str(deep)) == path
+
+    def test_stops_at_the_repository_boundary(self, tmp_path):
+        """Discovery must not escape the repo and pick up an unrelated file
+        from a parent checkout or the user's home directory."""
+        write(tmp_path / ".docksec.yml", "severity: LOW\n")
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        assert find_config_file(str(repo)) is None
+
+    def test_nearest_config_wins(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        write(tmp_path / ".docksec.yml", "severity: LOW\n")
+        nested = tmp_path / "service"
+        nested.mkdir()
+        nearest = write(nested / ".docksec.yml", "severity: HIGH\n")
+        assert find_config_file(str(nested)) == nearest
+
+    def test_returns_none_when_absent(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        assert find_config_file(str(tmp_path)) is None
+
+
+class TestJsonSchema:
+    def test_schema_has_expected_shape(self):
+        schema = config_json_schema()
+        assert schema["$schema"].startswith("http://json-schema.org/")
+        assert schema["additionalProperties"] is False
+        for key in ("severity", "fail_on", "formats", "output_dir", "rules"):
+            assert key in schema["properties"]
+
+    def test_committed_schema_is_up_to_date(self):
+        """The committed schema is what editors fetch for autocomplete; if this
+        fails, regenerate with `docksec --print-config-schema`."""
+        repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        committed_path = os.path.join(repo_root, "docs", "docksec-config-schema.json")
+        with open(committed_path, "r", encoding="utf-8") as handle:
+            committed = json.load(handle)
+        assert committed == config_json_schema(), (
+            "docs/docksec-config-schema.json is stale; "
+            "regenerate with 'docksec --print-config-schema'"
+        )
+
+
+class TestMergeIntoArgs:
+    """Direct tests of cli._load_project_config.
+
+    Settings that travel via environment variables (provider, model, severity)
+    and the boolean flags are easiest to assert precisely here, rather than
+    inferring them from scan output.
+    """
+
+    @staticmethod
+    def blank_args(**overrides):
+        import argparse
+
+        defaults = dict(
+            no_config=False, config_file=None, severity=None, fail_on=None,
+            output_dir=None, ignore_file=None, baseline=None, offline=None,
+            skip_ai_scoring=None, no_redact=None, no_cache=None, format=None,
+        )
+        defaults.update(overrides)
+        return argparse.Namespace(**defaults)
+
+    @pytest.fixture(autouse=True)
+    def clean_env(self, monkeypatch):
+        for key in ("LLM_PROVIDER", "LLM_MODEL", "DOCKSEC_DEFAULT_SEVERITY"):
+            monkeypatch.delenv(key, raising=False)
+        # These tests chdir into a tmp_path to exercise discovery; restore the
+        # original directory so the rest of the suite is unaffected.
+        original = os.getcwd()
+        yield
+        os.chdir(original)
+
+    @staticmethod
+    def load(tmp_path, text, args):
+        from docksec import output
+        from docksec.cli import _load_project_config
+
+        write(tmp_path / ".docksec.yml", text)
+        os.chdir(tmp_path)
+        return _load_project_config(args, output)
+
+    def test_booleans_are_applied(self, tmp_path):
+        args = self.blank_args()
+        self.load(tmp_path, "offline: true\nno_cache: true\nno_redact: true\n", args)
+        assert args.offline is True
+        assert args.no_cache is True
+        assert args.no_redact is True
+
+    def test_explicit_false_in_file_is_applied(self, tmp_path):
+        """An explicit false must be distinguishable from an absent key."""
+        args = self.blank_args()
+        self.load(tmp_path, "offline: false\n", args)
+        assert args.offline is False
+
+    def test_cli_flag_is_not_overwritten(self, tmp_path):
+        args = self.blank_args(offline=True, fail_on="CRITICAL")
+        self.load(tmp_path, "offline: false\nfail_on: LOW\n", args)
+        assert args.offline is True
+        assert args.fail_on == "CRITICAL"
+
+    def test_provider_and_model_reach_the_environment(self, tmp_path):
+        self.load(
+            tmp_path,
+            "provider: anthropic\nmodel: claude-haiku-4-5\n",
+            self.blank_args(),
+        )
+        assert os.environ["LLM_PROVIDER"] == "anthropic"
+        assert os.environ["LLM_MODEL"] == "claude-haiku-4-5"
+
+    def test_exported_provider_beats_the_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("LLM_PROVIDER", "openai")
+        self.load(tmp_path, "provider: anthropic\n", self.blank_args())
+        assert os.environ["LLM_PROVIDER"] == "openai"
+
+    def test_exported_severity_beats_the_file(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("DOCKSEC_DEFAULT_SEVERITY", "LOW")
+        self.load(tmp_path, "severity: CRITICAL\n", self.blank_args())
+        assert os.environ["DOCKSEC_DEFAULT_SEVERITY"] == "LOW"
+
+    def test_formats_list_becomes_a_comma_string(self, tmp_path):
+        args = self.blank_args()
+        self.load(tmp_path, "formats: [html, json]\n", args)
+        assert args.format == "json,html"
+
+    def test_no_config_skips_the_file_entirely(self, tmp_path):
+        args = self.blank_args(no_config=True)
+        _, path = self.load(tmp_path, "offline: true\n", args)
+        assert path is None
+        assert args.offline is None
+
+
+class TestCliIntegration:
+    """End-to-end precedence checks through the real CLI process.
+
+    These run the CLI as a subprocess because precedence depends on import
+    order and environment state that an in-process call would not reproduce.
+    """
+
+    @staticmethod
+    def run(cwd, *args, env=None):
+        repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        full_env = {**os.environ, "PYTHONPATH": repo_root, "NO_COLOR": "1"}
+        # Keep the developer's own environment from leaking into precedence tests.
+        for key in ("DOCKSEC_DEFAULT_SEVERITY", "LLM_PROVIDER", "LLM_MODEL"):
+            full_env.pop(key, None)
+        full_env.update(env or {})
+        return subprocess.run(
+            [sys.executable, "-m", "docksec.cli", *args],
+            cwd=str(cwd),
+            capture_output=True,
+            text=True,
+            env=full_env,
+            timeout=120,
+        )
+
+    @pytest.fixture
+    def project(self, tmp_path):
+        (tmp_path / ".git").mkdir()
+        (tmp_path / "Dockerfile").write_text("FROM alpine:3.19\n", encoding="utf-8")
+        return tmp_path
+
+    def test_config_file_sets_severity(self, project):
+        write(project / ".docksec.yml", "severity: MEDIUM,HIGH,CRITICAL\n")
+        result = self.run(project, "Dockerfile", "--scan-only")
+        assert "MEDIUM,HIGH,CRITICAL" in result.stdout
+        assert ".docksec.yml" in result.stdout
+
+    def test_cli_flag_overrides_config_file(self, project):
+        write(project / ".docksec.yml", "severity: LOW\n")
+        result = self.run(project, "Dockerfile", "--scan-only", "--severity", "CRITICAL")
+        assert "Severity    CRITICAL" in result.stdout
+
+    def test_env_var_overrides_config_file(self, project):
+        write(project / ".docksec.yml", "severity: LOW\n")
+        result = self.run(
+            project, "Dockerfile", "--scan-only",
+            env={"DOCKSEC_DEFAULT_SEVERITY": "CRITICAL"},
+        )
+        assert "Severity    CRITICAL" in result.stdout
+
+    def test_no_config_ignores_the_file(self, project):
+        write(project / ".docksec.yml", "severity: LOW\n")
+        result = self.run(project, "Dockerfile", "--scan-only", "--no-config")
+        assert "Severity    CRITICAL,HIGH" in result.stdout
+        assert "Config" not in result.stdout
+
+    def test_invalid_config_exits_2(self, project):
+        write(project / ".docksec.yml", "severty: HIGH\n")
+        result = self.run(project, "Dockerfile", "--scan-only")
+        assert result.returncode == 2
+        assert "unknown setting" in result.stdout + result.stderr
+
+    def test_missing_explicit_config_exits_2(self, project):
+        result = self.run(project, "Dockerfile", "--scan-only", "--config", "absent.yml")
+        assert result.returncode == 2
+
+    def test_subdirectory_inherits_root_config(self, project):
+        write(project / ".docksec.yml", "severity: MEDIUM,HIGH,CRITICAL\n")
+        nested = project / "services" / "api"
+        nested.mkdir(parents=True)
+        result = self.run(nested, "../../Dockerfile", "--scan-only")
+        assert "MEDIUM,HIGH,CRITICAL" in result.stdout
+
+    def test_print_config_schema_emits_valid_json(self, project):
+        result = self.run(project, "--print-config-schema")
+        assert result.returncode == 0
+        assert json.loads(result.stdout)["properties"]["severity"]
+
+    def test_disabled_rules_are_dropped_everywhere(self, project):
+        """A disabled rule must not reach --json, and by extension not the
+        score, the reports, or the --fail-on gate."""
+        compose = project / "docker-compose.yml"
+        compose.write_text(
+            "services:\n"
+            "  web:\n"
+            "    image: nginx:latest\n"
+            "    ports:\n"
+            "      - '6379:6379'\n",
+            encoding="utf-8",
+        )
+
+        before = self.run(project, "--compose", "docker-compose.yml", "--scan-only", "--json")
+        ids_before = {
+            item["VulnerabilityID"] for item in json.loads(before.stdout)["vulnerabilities"]
+        }
+        assert "compose-no-resource-limits" in ids_before
+
+        write(
+            project / ".docksec.yml",
+            "rules:\n  disabled:\n    - compose-no-resource-limits\n",
+        )
+        after = self.run(project, "--compose", "docker-compose.yml", "--scan-only", "--json")
+        ids_after = {
+            item["VulnerabilityID"] for item in json.loads(after.stdout)["vulnerabilities"]
+        }
+        assert "compose-no-resource-limits" not in ids_after
+        assert ids_after < ids_before
+
+    def test_disabled_rule_matching_is_case_insensitive(self, project):
+        compose = project / "docker-compose.yml"
+        compose.write_text(
+            "services:\n  web:\n    image: nginx:latest\n", encoding="utf-8"
+        )
+        write(
+            project / ".docksec.yml",
+            "rules:\n  disabled:\n    - COMPOSE-LATEST-OR-UNTAGGED-IMAGE\n",
+        )
+        result = self.run(project, "--compose", "docker-compose.yml", "--scan-only", "--json")
+        ids = {item["VulnerabilityID"] for item in json.loads(result.stdout)["vulnerabilities"]}
+        assert "compose-latest-or-untagged-image" not in ids


### PR DESCRIPTION
## Summary

Adds a committed `.docksec.yml` so a team's scan policy lives in the repository
instead of in per-developer flags and environment variables.

Settings covered: `severity`, `fail_on`, `formats`, `output_dir`, `provider`,
`model`, `offline`, `skip_ai_scoring`, `no_redact`, `no_cache`, `ignore_file`,
`baseline`, and `rules.disabled`.

```yaml
# yaml-language-server: $schema=https://owasp.org/DockSec/docksec-config-schema.json
severity: CRITICAL,HIGH
fail_on: HIGH
formats: [json, html]
output_dir: ./security-reports

rules:
  disabled:
    - compose-missing-healthcheck
