### PR TITLE
feat: replace string-substitution HTML templates with Jinja2 (#51)

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,6 @@ include LICENSE
 include README.md
 include requirements.txt
 include .env.example
-recursive-include docksec/templates *.html
+recursive-include docksec/templates *
 recursive-include tests *
 global-exclude *.py[cod] __pycache__ *.so .DS_Store

--- a/docksec/config.py
+++ b/docksec/config.py
@@ -73,17 +73,15 @@ def get_html_template() -> str:
     """
     Load the HTML report template from the templates directory.
     """
-    template_path = os.path.join(TEMPLATES_DIR, "report_template.html")
-    try:
+    for filename in ("report.html.j2", "report_template.html"):
+        template_path = os.path.join(TEMPLATES_DIR, filename)
         if os.path.exists(template_path):
-            with open(template_path, 'r', encoding='utf-8') as f:
-                return f.read()
-        else:
-            # Fallback for when running from a location where templates might not be correctly linked
-            # This is a safety measure
-            return "<html><body><h1>Docker Security Report</h1><p>Template missing at " + template_path + "</p></body></html>"
-    except Exception as e:
-        return f"<html><body><h1>Error</h1><p>{str(e)}</p></body></html>"
+            try:
+                with open(template_path, 'r', encoding='utf-8') as f:
+                    return f.read()
+            except Exception as e:
+                return f"<html><body><h1>Error</h1><p>{str(e)}</p></body></html>"
+    return "<html><body><h1>Docker Security Report</h1><p>Template missing in " + TEMPLATES_DIR + "</p></body></html>"
 
 
 # For backward compatibility with existing code that imports html_template

--- a/docksec/config.py
+++ b/docksec/config.py
@@ -73,14 +73,13 @@ def get_html_template() -> str:
     """
     Load the HTML report template from the templates directory.
     """
-    for filename in ("report.html.j2", "report_template.html"):
-        template_path = os.path.join(TEMPLATES_DIR, filename)
-        if os.path.exists(template_path):
-            try:
-                with open(template_path, 'r', encoding='utf-8') as f:
-                    return f.read()
-            except Exception as e:
-                return f"<html><body><h1>Error</h1><p>{str(e)}</p></body></html>"
+    template_path = os.path.join(TEMPLATES_DIR, "report.html.j2")
+    if os.path.exists(template_path):
+        try:
+            with open(template_path, 'r', encoding='utf-8') as f:
+                return f.read()
+        except Exception as e:
+            return f"<html><body><h1>Error</h1><p>{str(e)}</p></body></html>"
     return "<html><body><h1>Docker Security Report</h1><p>Template missing in " + TEMPLATES_DIR + "</p></body></html>"
 
 

--- a/docksec/report_generator.py
+++ b/docksec/report_generator.py
@@ -21,7 +21,7 @@ from datetime import datetime
 from typing import Dict, List, Optional
 
 from docksec import output
-from docksec.config import RESULTS_DIR, TEMPLATES_DIR, get_html_template
+from docksec.config import RESULTS_DIR, TEMPLATES_DIR
 from docksec.utils import get_custom_logger
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 

--- a/docksec/report_generator.py
+++ b/docksec/report_generator.py
@@ -21,8 +21,9 @@ from datetime import datetime
 from typing import Dict, List, Optional
 
 from docksec import output
-from docksec.config import RESULTS_DIR, get_html_template
+from docksec.config import RESULTS_DIR, TEMPLATES_DIR, get_html_template
 from docksec.utils import get_custom_logger
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 # fpdf2 emits a UserWarning at import time when the legacy PyFPDF package shares
 # the same module namespace. It is environmental noise that is not actionable
@@ -701,12 +702,31 @@ class ReportGenerator:
         logger.info(f"Generating HTML report: {output_file}")
 
         try:
-            template_vars = self._prepare_html_template_vars(results)
+            vulnerabilities = results.get("json_data", [])
+            scan_mode = results.get("scan_mode", "full")
+            severity_counts = self._count_by_severity(vulnerabilities)
 
-            # Replace placeholders in template
-            html_content = get_html_template()
-            for key, value in template_vars.items():
-                html_content = html_content.replace(f"{{{{{key}}}}}", str(value))
+            env = Environment(
+                loader=FileSystemLoader(TEMPLATES_DIR),
+                autoescape=select_autoescape(["html", "htm", "xml", "j2"]),
+            )
+            template = env.get_template("report.html.j2")
+            html_content = template.render(
+                image_name=self.image_name,
+                scan_mode=scan_mode.replace("_", " ").title(),
+                scan_mode_title=f"{scan_mode.replace('_', ' ').title()} Scan",
+                dockerfile_path=results.get("dockerfile_path", "N/A"),
+                scan_date=results.get("timestamp", ""),
+                analysis_score=self.analysis_score,
+                image_info=results.get("image_info"),
+                config_analysis=results.get("config_analysis"),
+                ai_findings=results.get("ai_findings"),
+                dockerfile_scan=results.get("dockerfile_scan", {"skipped": True}),
+                vulnerabilities=vulnerabilities,
+                severity_counts=severity_counts,
+                suppressed_count=results.get("suppressed_count"),
+                ignore_file=results.get("ignore_file"),
+            )
 
             # Save the HTML file
             with open(output_file, "w", encoding="utf-8") as f:
@@ -844,355 +864,6 @@ class ReportGenerator:
             output.error(f"Failed to save Markdown report: {e}")
             return ""
 
-    def _prepare_html_template_vars(self, results: Dict) -> Dict[str, str]:
-        """
-        Prepare variables for HTML template replacement.
-
-        Args:
-            results: Scan results dictionary
-
-        Returns:
-            Dictionary of template variables
-        """
-        vulnerabilities = results.get("json_data", [])
-        scan_mode = results.get("scan_mode", "full")
-
-        template_vars = {
-            "IMAGE_NAME": self.image_name,
-            "SCAN_MODE": scan_mode.replace("_", " ").title(),
-            "SCAN_MODE_TITLE": f"{scan_mode.replace('_', ' ').title()} Scan",
-            "DOCKERFILE_PATH": results.get("dockerfile_path", "N/A"),
-            "SCAN_DATE": results.get("timestamp", ""),
-            "ANALYSIS_SCORE": (
-                str(self.analysis_score) if self.analysis_score else "N/A"
-            ),
-        }
-
-        # Security Score Section (rating bands match the terminal summary in
-        # docksec.output._score_band)
-        score_rating_html = ""
-        if self.analysis_score is not None:
-            score = float(self.analysis_score)
-            if score >= 90:
-                rating, rating_class = "Excellent", "rating-excellent"
-            elif score >= 70:
-                rating, rating_class = "Good", "rating-good"
-            elif score >= 50:
-                rating, rating_class = "Fair", "rating-fair"
-            else:
-                rating, rating_class = "Poor", "rating-poor"
-            score_rating_html = f'<div class="score-rating {rating_class}">{rating}</div>'
-
-        template_vars["SECURITY_SCORE_SECTION"] = f"""
-        <div class="section">
-            <h2>Security Score</h2>
-            <div class="score-container">
-                <div class="score-label">Overall Security Score</div>
-                <div class="score-value">{self.analysis_score if self.analysis_score is not None else 'N/A'}/100</div>
-                {score_rating_html}
-            </div>
-        </div>
-        """
-
-        # Image Information Section
-        if "image_info" in results:
-            image_info = results["image_info"]
-            size_mb = (
-                round(image_info.get("size", 0) / (1024 * 1024), 2)
-                if image_info.get("size")
-                else "N/A"
-            )
-
-            template_vars["IMAGE_INFO_SECTION"] = f"""
-            <div class="section">
-                <h2>Image Information</h2>
-                <div class="info-grid">
-                    <div class="info-item">
-                        <div class="info-label">Size</div>
-                        <div class="info-value">{size_mb} MB</div>
-                    </div>
-                    <div class="info-item">
-                        <div class="info-label">Created</div>
-                        <div class="info-value">{image_info.get('created', 'N/A')[:19]}</div>
-                    </div>
-                    <div class="info-item">
-                        <div class="info-label">Architecture</div>
-                        <div class="info-value">{image_info.get('architecture', 'N/A')}</div>
-                    </div>
-                    <div class="info-item">
-                        <div class="info-label">OS</div>
-                        <div class="info-value">{image_info.get('os', 'N/A')}</div>
-                    </div>
-                </div>
-            </div>
-            """
-        else:
-            template_vars["IMAGE_INFO_SECTION"] = ""
-
-        # Configuration Analysis Section
-        if "config_analysis" in results:
-            config_analysis = results["config_analysis"]
-            config_html = (
-                '<div class="section"><h2>Configuration Analysis</h2><div class="config-issues">'
-            )
-
-            # High risk issues
-            if config_analysis.get("high_risk"):
-                config_html += '<div class="config-category"><h4>High-Risk Issues</h4><ul class="config-list high">'
-                for issue in config_analysis["high_risk"]:
-                    config_html += f"<li>{self._escape_html(issue)}</li>"
-                config_html += "</ul></div>"
-
-            # Medium risk issues
-            if config_analysis.get("medium_risk"):
-                config_html += '<div class="config-category"><h4>Medium-Risk Issues</h4><ul class="config-list medium">'
-                for issue in config_analysis["medium_risk"]:
-                    config_html += f"<li>{self._escape_html(issue)}</li>"
-                config_html += "</ul></div>"
-
-            # Low risk issues
-            if config_analysis.get("low_risk"):
-                config_html += '<div class="config-category"><h4>Low-Risk Issues</h4><ul class="config-list low">'
-                for issue in config_analysis["low_risk"]:
-                    config_html += f"<li>{self._escape_html(issue)}</li>"
-                config_html += "</ul></div>"
-
-            config_html += "</div></div>"
-            template_vars["CONFIG_ANALYSIS_SECTION"] = config_html
-        else:
-            template_vars["CONFIG_ANALYSIS_SECTION"] = ""
-
-        # AI Dockerfile Analysis Section. Renders the full LLM findings (the
-        # terminal shows only a truncated preview), so this is where the user
-        # reads the complete list. Empty when no AI analysis ran.
-        template_vars["AI_ANALYSIS_SECTION"] = self._build_ai_analysis_html(
-            results.get("ai_findings")
-        )
-
-        # Dockerfile Section
-        if not results["dockerfile_scan"].get("skipped", False):
-            if results["dockerfile_scan"]["success"]:
-                dockerfile_content = (
-                    '<div class="no-issues">No Dockerfile linting issues found</div>'
-                )
-            else:
-                dockerfile_output = results["dockerfile_scan"].get("output", "")
-                dockerfile_content = f'<pre class="mono-block">{self._escape_html(dockerfile_output[:2000])}</pre>'
-                if len(dockerfile_output) > 2000:
-                    dockerfile_content += (
-                        "<p><em>Output truncated for display...</em></p>"
-                    )
-
-            template_vars["DOCKERFILE_SECTION"] = f"""
-            <div class="section">
-                <h2>Dockerfile Scan Results</h2>
-                {dockerfile_content}
-            </div>
-            """
-        else:
-            template_vars["DOCKERFILE_SECTION"] = ""
-
-        # Vulnerability Summary
-        if not vulnerabilities:
-            no_issues_html = '<div class="no-issues">No vulnerabilities found</div>'
-            suppressed = results.get("suppressed_count")
-            if suppressed:
-                ignore_file = self._escape_html(str(results.get("ignore_file", "")))
-                no_issues_html += (
-                    f"<p><strong>Waived:</strong> {suppressed} triaged finding(s) "
-                    f"suppressed via ignore file {ignore_file}</p>"
-                )
-            template_vars["VULNERABILITY_SUMMARY"] = no_issues_html
-            template_vars["DETAILED_VULNERABILITIES_SECTION"] = ""
-        else:
-            severity_counts = self._count_by_severity(vulnerabilities)
-
-            severity_html = f"""
-            <div class="severity-stats">
-                <div class="severity-item severity-critical">
-                    <div class="severity-count">{severity_counts.get('CRITICAL', 0)}</div>
-                    <div class="severity-label">Critical</div>
-                </div>
-                <div class="severity-item severity-high">
-                    <div class="severity-count">{severity_counts.get('HIGH', 0)}</div>
-                    <div class="severity-label">High</div>
-                </div>
-                <div class="severity-item severity-medium">
-                    <div class="severity-count">{severity_counts.get('MEDIUM', 0)}</div>
-                    <div class="severity-label">Medium</div>
-                </div>
-                <div class="severity-item severity-low">
-                    <div class="severity-count">{severity_counts.get('LOW', 0)}</div>
-                    <div class="severity-label">Low</div>
-                </div>
-            </div>
-            <p><strong>Total vulnerabilities:</strong> {len(vulnerabilities)}</p>
-            """
-
-            fixable = sum(1 for v in vulnerabilities if v.get("FixedVersion"))
-            if fixable:
-                severity_html += (
-                    f"<p><strong>Fix available:</strong> {fixable} of "
-                    f"{len(vulnerabilities)} findings have a fixed version upstream</p>"
-                )
-            suppressed = results.get("suppressed_count")
-            if suppressed:
-                ignore_file = self._escape_html(str(results.get("ignore_file", "")))
-                severity_html += (
-                    f"<p><strong>Waived:</strong> {suppressed} triaged finding(s) "
-                    f"suppressed via ignore file {ignore_file}</p>"
-                )
-
-            template_vars["VULNERABILITY_SUMMARY"] = severity_html
-
-            # Detailed vulnerabilities table
-            table_html = """
-            <div class="section">
-                <h2>Detailed Vulnerabilities</h2>
-                <div class="table-scroll">
-                <table class="vulnerability-table">
-                    <thead>
-                        <tr>
-                            <th>ID</th>
-                            <th>Severity</th>
-                            <th>Package</th>
-                            <th>Installed</th>
-                            <th>Fixed In</th>
-                            <th>Title</th>
-                            <th>CVSS</th>
-                            <th>Status</th>
-                        </tr>
-                    </thead>
-                    <tbody>
-            """
-
-            for vuln in vulnerabilities[:50]:
-                severity = vuln.get("Severity", "UNKNOWN").lower()
-                severity_class = (
-                    f"badge-{severity}"
-                    if severity in ["critical", "high", "medium", "low"]
-                    else "badge-low"
-                )
-
-                status = vuln.get("Status", "affected")
-                status_class = (
-                    "status-fixed" if status == "fixed" else "status-affected"
-                )
-
-                cvss_score = vuln.get("CVSS", "N/A")
-                if cvss_score and cvss_score != "N/A":
-                    cvss_score = (
-                        f"{cvss_score:.1f}"
-                        if isinstance(cvss_score, (int, float))
-                        else str(cvss_score)
-                    )
-
-                vuln_id = vuln.get('VulnerabilityID') or 'N/A'
-                pkg_name = vuln.get('PkgName') or 'N/A'
-                installed_version = vuln.get('InstalledVersion') or 'N/A'
-                fixed_version = vuln.get('FixedVersion') or ''
-                fixed_cell = (
-                    f'<span class="fixed-version">{self._escape_html(fixed_version)}</span>'
-                    if fixed_version else '<span class="no-fix">none yet</span>'
-                )
-                title = vuln.get('Title') or 'N/A'
-                display_title = (title[:80] + '...') if len(title) > 80 else title
-
-                table_html += f"""
-                        <tr>
-                            <td><strong>{self._escape_html(vuln_id)}</strong></td>
-                            <td><span class="severity-badge {severity_class}">{vuln.get('Severity', 'N/A')}</span></td>
-                            <td>{self._escape_html(pkg_name)}</td>
-                            <td>{self._escape_html(installed_version)}</td>
-                            <td>{fixed_cell}</td>
-                            <td>{self._escape_html(display_title)}</td>
-                            <td>{cvss_score}</td>
-                            <td><span class="status-badge {status_class}">{status}</span></td>
-                        </tr>
-                """
-
-            table_html += """
-                    </tbody>
-                </table>
-                </div>
-            """
-
-            if len(vulnerabilities) > 50:
-                table_html += f'<p class="table-note">Showing 50 of {len(vulnerabilities)} vulnerabilities. See CSV/JSON for complete list.</p>'
-
-            table_html += "</div>"
-            template_vars["DETAILED_VULNERABILITIES_SECTION"] = table_html
-
-        return template_vars
-
-    def _build_ai_analysis_html(self, ai_findings: Optional[Dict]) -> str:
-        """
-        Build the AI Dockerfile Analysis HTML section from LLM findings.
-
-        Renders every finding in full (unlike the truncated terminal preview)
-        so the report is the authoritative place to read the complete list.
-
-        Args:
-            ai_findings: The "ai_findings" dict produced by analyze_security,
-                or None when no AI analysis ran.
-
-        Returns:
-            HTML string for the section, or "" when there are no findings.
-        """
-        if not ai_findings:
-            return ""
-
-        # (key, heading, config-list severity class) for each category.
-        categories = [
-            ("vulnerabilities", "Vulnerabilities", "high"),
-            ("security_risks", "Security Risks", "high"),
-            ("exposed_credentials", "Exposed Credentials", "high"),
-            ("best_practices", "Best Practices", "medium"),
-            ("remediation", "Remediation Steps", "low"),
-        ]
-
-        blocks = []
-        for key, heading, list_class in categories:
-            items = ai_findings.get(key) or []
-            if not items:
-                continue
-            list_items = "".join(
-                f"<li>{self._escape_html(str(item))}</li>" for item in items
-            )
-            blocks.append(
-                f'<div class="config-category">'
-                f"<h4>{self._escape_html(heading)} ({len(items)})</h4>"
-                f'<ul class="config-list {list_class}">{list_items}</ul>'
-                f"</div>"
-            )
-
-        if not blocks:
-            return ""
-
-        return (
-            '<div class="section"><h2>AI Dockerfile Analysis</h2>'
-            '<div class="config-issues">' + "".join(blocks) + "</div></div>"
-        )
-
-    def _escape_html(self, text: str) -> str:
-        """
-        Escape HTML special characters in text.
-
-        Uses Python's built-in html.escape() for complete HTML5
-        entity handling, replacing the previous hand-rolled table.
-
-        Args:
-            text: Text to escape
-
-        Returns:
-            HTML-escaped text
-        """
-        import html
-
-        if not text:
-            return ""
-        return html.escape(str(text), quote=True)
-
     def _escape_markdown(self, text) -> str:
         """
         Make text safe for Markdown tables.
@@ -1214,7 +885,6 @@ class ReportGenerator:
             .replace("|", "\\|")
             .replace("\n", " ")
         )
-
     def _count_by_severity(self, vulnerabilities: List[Dict]) -> Dict[str, int]:
         """
         Count vulnerabilities by severity level.

--- a/docksec/templates/report.html.j2
+++ b/docksec/templates/report.html.j2
@@ -246,6 +246,26 @@
         .status-fixed { background: rgba(5, 150, 105, 0.14); color: var(--ok); }
         .status-affected { background: rgba(220, 38, 38, 0.12); color: var(--critical); }
 
+        .fixed-version {
+            font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+            font-size: 0.88em;
+            color: var(--ok);
+            font-weight: 600;
+        }
+
+        .no-fix {
+            color: var(--text-muted);
+            font-style: italic;
+            font-size: 0.88em;
+        }
+
+        .table-note {
+            margin-top: 15px;
+            font-style: italic;
+            color: var(--text-muted);
+            font-size: 0.9em;
+        }
+
         .no-issues {
             text-align: center;
             padding: 32px 20px;
@@ -295,38 +315,19 @@
 
         .score-rating {
             display: inline-block;
-            margin-top: 10px;
+            margin-top: 8px;
             padding: 4px 14px;
             border-radius: 999px;
-            font-size: 0.8em;
+            font-size: 0.82em;
             font-weight: 700;
             text-transform: uppercase;
-            letter-spacing: 0.08em;
+            letter-spacing: 0.06em;
         }
 
         .rating-excellent { background: rgba(5, 150, 105, 0.14); color: var(--ok); }
-        .rating-good { background: rgba(5, 150, 105, 0.10); color: var(--ok); }
+        .rating-good { background: rgba(37, 99, 235, 0.12); color: var(--low); }
         .rating-fair { background: rgba(217, 119, 6, 0.14); color: var(--medium); }
         .rating-poor { background: rgba(220, 38, 38, 0.12); color: var(--critical); }
-
-        .fixed-version { color: var(--ok); font-weight: 600; }
-        .no-fix { color: var(--text-muted); font-style: italic; }
-
-        .table-note {
-            margin-top: 15px;
-            font-style: italic;
-            color: var(--text-muted);
-        }
-
-        .mono-block {
-            background: var(--surface-alt);
-            border: 1px solid var(--border);
-            color: var(--text);
-            padding: 15px;
-            border-radius: 8px;
-            overflow-x: auto;
-            font-size: 0.9em;
-        }
 
         .config-issues { margin-top: 8px; }
         .config-category { margin-bottom: 18px; }
@@ -353,6 +354,14 @@
 
         .config-list.medium li { border-left-color: var(--medium); }
         .config-list.low li { border-left-color: var(--low); }
+
+        .mono-block {
+            background: #f8f9fa;
+            padding: 15px;
+            border-radius: 5px;
+            overflow-x: auto;
+            font-size: 0.9em;
+        }
 
         .footer {
             text-align: center;
@@ -381,7 +390,7 @@
         <div class="header">
             <div class="brand">DockSec Security Report</div>
             <h1>Docker Security Report</h1>
-            <p>{{SCAN_MODE_TITLE}}</p>
+            <p>{{ scan_mode_title }}</p>
         </div>
 
         <div class="content">
@@ -391,54 +400,243 @@
                 <div class="info-grid">
                     <div class="info-item">
                         <div class="info-label">Image Name</div>
-                        <div class="info-value">{{IMAGE_NAME}}</div>
+                        <div class="info-value">{{ image_name }}</div>
                     </div>
                     <div class="info-item">
                         <div class="info-label">Scan Mode</div>
-                        <div class="info-value">{{SCAN_MODE}}</div>
+                        <div class="info-value">{{ scan_mode }}</div>
                     </div>
                     <div class="info-item">
                         <div class="info-label">Dockerfile Path</div>
-                        <div class="info-value">{{DOCKERFILE_PATH}}</div>
+                        <div class="info-value">{{ dockerfile_path }}</div>
                     </div>
                     <div class="info-item">
                         <div class="info-label">Scan Date</div>
-                        <div class="info-value">{{SCAN_DATE}}</div>
+                        <div class="info-value">{{ scan_date }}</div>
                     </div>
                     <div class="info-item">
                         <div class="info-label">Analysis Score</div>
-                        <div class="info-value">{{ANALYSIS_SCORE}}</div>
+                        <div class="info-value">{{ analysis_score if analysis_score is not none else 'N/A' }}</div>
                     </div>
                 </div>
             </div>
 
             <!-- Security Score Section -->
-            {{SECURITY_SCORE_SECTION}}
+            <div class="section">
+                <h2>Security Score</h2>
+                <div class="score-container">
+                    <div class="score-label">Overall Security Score</div>
+                    <div class="score-value">{{ analysis_score if analysis_score is not none else 'N/A' }}/100</div>
+                    {% if analysis_score is not none %}
+                    {% set score = analysis_score | float %}
+                    {% if score >= 90 %}
+                    <div class="score-rating rating-excellent">Excellent</div>
+                    {% elif score >= 70 %}
+                    <div class="score-rating rating-good">Good</div>
+                    {% elif score >= 50 %}
+                    <div class="score-rating rating-fair">Fair</div>
+                    {% else %}
+                    <div class="score-rating rating-poor">Poor</div>
+                    {% endif %}
+                    {% endif %}
+                </div>
+            </div>
 
             <!-- Image Information Section -->
-            {{IMAGE_INFO_SECTION}}
+            {% if image_info %}
+            <div class="section">
+                <h2>Image Information</h2>
+                <div class="info-grid">
+                    <div class="info-item">
+                        <div class="info-label">Size</div>
+                        <div class="info-value">{{ (image_info.size / 1048576) | round(2) if image_info.get('size') else 'N/A' }} MB</div>
+                    </div>
+                    <div class="info-item">
+                        <div class="info-label">Created</div>
+                        <div class="info-value">{{ image_info.get('created', 'N/A')[:19] }}</div>
+                    </div>
+                    <div class="info-item">
+                        <div class="info-label">Architecture</div>
+                        <div class="info-value">{{ image_info.get('architecture', 'N/A') }}</div>
+                    </div>
+                    <div class="info-item">
+                        <div class="info-label">OS</div>
+                        <div class="info-value">{{ image_info.get('os', 'N/A') }}</div>
+                    </div>
+                </div>
+            </div>
+            {% endif %}
 
             <!-- Configuration Analysis Section -->
-            {{CONFIG_ANALYSIS_SECTION}}
+            {% if config_analysis and (config_analysis.get('high_risk') or config_analysis.get('medium_risk') or config_analysis.get('low_risk')) %}
+            <div class="section">
+                <h2>Configuration Analysis</h2>
+                <div class="config-issues">
+                    {% if config_analysis.get('high_risk') %}
+                    <div class="config-category">
+                        <h4>High-Risk Issues</h4>
+                        <ul class="config-list high">
+                            {% for issue in config_analysis.high_risk %}
+                            <li>{{ issue }}</li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                    {% endif %}
+                    {% if config_analysis.get('medium_risk') %}
+                    <div class="config-category">
+                        <h4>Medium-Risk Issues</h4>
+                        <ul class="config-list medium">
+                            {% for issue in config_analysis.medium_risk %}
+                            <li>{{ issue }}</li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                    {% endif %}
+                    {% if config_analysis.get('low_risk') %}
+                    <div class="config-category">
+                        <h4>Low-Risk Issues</h4>
+                        <ul class="config-list low">
+                            {% for issue in config_analysis.low_risk %}
+                            <li>{{ issue }}</li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                    {% endif %}
+                </div>
+            </div>
+            {% endif %}
 
             <!-- AI Dockerfile Analysis Section -->
-            {{AI_ANALYSIS_SECTION}}
+            {% if ai_findings and (ai_findings.get('vulnerabilities') or ai_findings.get('security_risks') or ai_findings.get('exposed_credentials') or ai_findings.get('best_practices') or ai_findings.get('remediation')) %}
+            <div class="section">
+                <h2>AI Dockerfile Analysis</h2>
+                <div class="config-issues">
+                    {% for key, heading, list_class in [
+                        ('vulnerabilities', 'Vulnerabilities', 'high'),
+                        ('security_risks', 'Security Risks', 'high'),
+                        ('exposed_credentials', 'Exposed Credentials', 'high'),
+                        ('best_practices', 'Best Practices', 'medium'),
+                        ('remediation', 'Remediation Steps', 'low')
+                    ] %}
+                        {% if ai_findings.get(key) %}
+                        <div class="config-category">
+                            <h4>{{ heading }} ({{ ai_findings[key] | length }})</h4>
+                            <ul class="config-list {{ list_class }}">
+                                {% for item in ai_findings[key] %}
+                                <li>{{ item }}</li>
+                                {% endfor %}
+                            </ul>
+                        </div>
+                        {% endif %}
+                    {% endfor %}
+                </div>
+            </div>
+            {% endif %}
 
             <!-- Dockerfile Scan Results Section -->
-            {{DOCKERFILE_SECTION}}
+            {% if dockerfile_scan and not dockerfile_scan.get('skipped', False) %}
+            <div class="section">
+                <h2>Dockerfile Scan Results</h2>
+                {% if dockerfile_scan.get('success') %}
+                <div class="no-issues">No Dockerfile linting issues found</div>
+                {% else %}
+                {% set df_output = dockerfile_scan.get('output', '') %}
+                <pre class="mono-block">{{ df_output[:2000] }}</pre>
+                {% if df_output | length > 2000 %}
+                <p><em>Output truncated for display...</em></p>
+                {% endif %}
+                {% endif %}
+            </div>
+            {% endif %}
 
             <!-- Vulnerability Summary Section -->
             <div class="section">
                 <h2>Vulnerability Summary</h2>
-                {{VULNERABILITY_SUMMARY}}
+                {% if not vulnerabilities %}
+                <div class="no-issues">No vulnerabilities found</div>
+                {% if suppressed_count %}
+                <p><strong>Waived:</strong> {{ suppressed_count }} triaged finding(s) suppressed via ignore file {{ ignore_file }}</p>
+                {% endif %}
+                {% else %}
+                <div class="severity-stats">
+                    <div class="severity-item severity-critical">
+                        <div class="severity-count">{{ severity_counts.get('CRITICAL', 0) }}</div>
+                        <div class="severity-label">Critical</div>
+                    </div>
+                    <div class="severity-item severity-high">
+                        <div class="severity-count">{{ severity_counts.get('HIGH', 0) }}</div>
+                        <div class="severity-label">High</div>
+                    </div>
+                    <div class="severity-item severity-medium">
+                        <div class="severity-count">{{ severity_counts.get('MEDIUM', 0) }}</div>
+                        <div class="severity-label">Medium</div>
+                    </div>
+                    <div class="severity-item severity-low">
+                        <div class="severity-count">{{ severity_counts.get('LOW', 0) }}</div>
+                        <div class="severity-label">Low</div>
+                    </div>
+                </div>
+                <p><strong>Total vulnerabilities:</strong> {{ vulnerabilities | length }}</p>
+                {% set fixable = vulnerabilities | selectattr('FixedVersion', 'defined') | selectattr('FixedVersion') | list | length %}
+                {% if fixable > 0 %}
+                <p><strong>Fix available:</strong> {{ fixable }} of {{ vulnerabilities | length }} findings have a fixed version upstream</p>
+                {% endif %}
+                {% if suppressed_count %}
+                <p><strong>Waived:</strong> {{ suppressed_count }} triaged finding(s) suppressed via ignore file {{ ignore_file }}</p>
+                {% endif %}
+                {% endif %}
             </div>
 
+            {% if vulnerabilities %}
             <!-- Detailed Vulnerabilities Section -->
-            {{DETAILED_VULNERABILITIES_SECTION}}
+            <div class="section">
+                <h2>Detailed Vulnerabilities</h2>
+                <div class="table-scroll">
+                <table class="vulnerability-table">
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Severity</th>
+                            <th>Package</th>
+                            <th>Installed</th>
+                            <th>Fixed In</th>
+                            <th>Title</th>
+                            <th>CVSS</th>
+                            <th>Status</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for vuln in vulnerabilities[:50] %}
+                        {% set severity = (vuln.get('Severity') or 'UNKNOWN') | lower %}
+                        {% set severity_class = 'badge-' ~ severity if severity in ['critical', 'high', 'medium', 'low'] else 'badge-low' %}
+                        {% set status = vuln.get('Status') or 'affected' %}
+                        {% set status_class = 'status-fixed' if status == 'fixed' else 'status-affected' %}
+                        {% set title = vuln.get('Title') or 'N/A' %}
+                        {% set cvss_val = vuln.get('CVSS') %}
+                        {% set fixed_version = vuln.get('FixedVersion') %}
+                        <tr>
+                            <td><strong>{{ vuln.get('VulnerabilityID') or 'N/A' }}</strong></td>
+                            <td><span class="severity-badge {{ severity_class }}">{{ vuln.get('Severity') or 'N/A' }}</span></td>
+                            <td>{{ vuln.get('PkgName') or 'N/A' }}</td>
+                            <td>{{ vuln.get('InstalledVersion') or 'N/A' }}</td>
+                            <td>{% if fixed_version %}<span class="fixed-version">{{ fixed_version }}</span>{% else %}<span class="no-fix">none yet</span>{% endif %}</td>
+                            <td>{{ (title[:80] ~ '...') if title | length > 80 else title }}</td>
+                            <td>{{ "%.1f" | format(cvss_val) if cvss_val is number else (cvss_val if cvss_val else 'N/A') }}</td>
+                            <td><span class="status-badge {{ status_class }}">{{ status }}</span></td>
+                        </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+                </div>
+                {% if vulnerabilities | length > 50 %}
+                <p class="table-note">Showing 50 of {{ vulnerabilities | length }} vulnerabilities. See CSV/JSON for complete list.</p>
+                {% endif %}
+            </div>
+            {% endif %}
         </div>
 
         <div class="footer">
-            <p>Generated by <a href="https://owasp.org/DockSec/">DockSec</a> on {{SCAN_DATE}}</p>
+            <p>Generated by <a href="https://owasp.org/DockSec/">DockSec</a> on {{ scan_date }}</p>
         </div>
     </div>
 </body>

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ python-dotenv>=1.0,<2
 colorama>=0.4.6,<1
 rich>=13.0,<16
 fpdf2>=2.8,<3
+jinja2>=3.1.0
 ruamel.yaml>=0.18.6
 setuptools>=82.0.1
 

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "fpdf2>=2.8,<3",
         "setuptools>=65.0.0",
         "ruamel.yaml>=0.18.6",
+        "jinja2>=3.1.0",
     ],
     extras_require={
         "dev": [
@@ -60,6 +61,6 @@ setup(
     ],
     include_package_data=True,
     package_data={
-        'docksec': ['templates/*.html'],
+        'docksec': ['templates/*'],
     },
 )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -169,6 +169,24 @@ class TestConfig(unittest.TestCase):
         self.assertIn("<html", template.lower())
         self.assertIn("Docker Security Report", template)
 
+    @patch("os.path.exists", return_value=False)
+    def test_get_html_template_missing(self, mock_exists):
+        """Test HTML template loading when template file is missing."""
+        from docksec.config import get_html_template
+        
+        template = get_html_template()
+        self.assertIn("Template missing", template)
+
+    @patch("os.path.exists", return_value=True)
+    @patch("builtins.open", side_effect=IOError("Permission denied"))
+    def test_get_html_template_error(self, mock_open, mock_exists):
+        """Test HTML template loading when reading fails."""
+        from docksec.config import get_html_template
+        
+        template = get_html_template()
+        self.assertIn("Error", template)
+        self.assertIn("Permission denied", template)
+
     def test_results_dir_default(self):
         """Test that RESULTS_DIR defaults to home directory."""
         from docksec.config import RESULTS_DIR

--- a/tests/test_report_generator.py
+++ b/tests/test_report_generator.py
@@ -364,6 +364,89 @@ def test_html_omits_ai_section_without_findings(tmp_path):
     assert "<h2>AI Dockerfile Analysis</h2>" not in content
 
 
+def test_html_renders_vulnerabilities_table_and_truncation(tmp_path):
+    vulns = [
+        {
+            "VulnerabilityID": f"CVE-2024-{1000 + i}",
+            "Severity": "CRITICAL" if i % 2 == 0 else "HIGH",
+            "PkgName": f"package-{i}",
+            "InstalledVersion": f"1.0.{i}",
+            "Title": f"Vulnerability title for issue {i}",
+            "CVSS": 8.5,
+            "Status": "fixed" if i % 2 == 0 else "affected",
+        }
+        for i in range(60)
+    ]
+    rg = ReportGenerator(image_name="test-image", results_dir=str(tmp_path))
+    results = make_results(vulns)
+    output_path = rg.generate_html_report(results)
+    with open(output_path, encoding="utf-8") as f:
+        content = f.read()
+
+    assert "<h2>Detailed Vulnerabilities</h2>" in content
+    assert "Total vulnerabilities:</strong> 60" in content
+    assert "Showing 50 of 60 vulnerabilities" in content
+    assert "CVE-2024-1000" in content
+    assert "CVE-2024-1049" in content
+    # The 51st vulnerability (index 50, id 1050) should not appear in the table
+    assert "CVE-2024-1050" not in content
+
+
+def test_html_empty_vulnerabilities_renders_success_state(tmp_path):
+    rg = ReportGenerator(image_name="test-image", results_dir=str(tmp_path))
+    results = make_results([])
+    output_path = rg.generate_html_report(results)
+    with open(output_path, encoding="utf-8") as f:
+        content = f.read()
+
+    assert "No vulnerabilities found" in content
+    assert "<h2>Detailed Vulnerabilities</h2>" not in content
+
+
+def test_html_renders_image_info_and_config_analysis(tmp_path):
+    rg = ReportGenerator(image_name="test-image", results_dir=str(tmp_path))
+    results = make_results([])
+    results["image_info"] = {
+        "size": 104857600,  # 100 MB
+        "created": "2026-01-01T12:00:00Z",
+        "architecture": "arm64",
+        "os": "alpine",
+    }
+    results["config_analysis"] = {
+        "high_risk": ["Root user configured"],
+        "medium_risk": ["Missing HEALTHCHECK"],
+        "low_risk": ["No label provided"],
+    }
+    output_path = rg.generate_html_report(results)
+    with open(output_path, encoding="utf-8") as f:
+        content = f.read()
+
+    assert "<h2>Image Information</h2>" in content
+    assert "100.0 MB" in content
+    assert "arm64" in content
+    assert "alpine" in content
+    assert "<h2>Configuration Analysis</h2>" in content
+    assert "Root user configured" in content
+    assert "Missing HEALTHCHECK" in content
+    assert "No label provided" in content
+
+
+def test_html_renders_dockerfile_scan_results(tmp_path):
+    rg = ReportGenerator(image_name="test-image", results_dir=str(tmp_path))
+    results = make_results([])
+    results["dockerfile_scan"] = {
+        "skipped": False,
+        "success": False,
+        "output": "DL3006 Always tag the version of an image explicitly",
+    }
+    output_path = rg.generate_html_report(results)
+    with open(output_path, encoding="utf-8") as f:
+        content = f.read()
+
+    assert "<h2>Dockerfile Scan Results</h2>" in content
+    assert "DL3006 Always tag the version of an image explicitly" in content
+
+
 # ---------- MARKDOWN REPORT TESTS ----------
 
 


### PR DESCRIPTION
Closes #51 

### Overview
Migrated HTML report generation from manual string replacement to Jinja2 with auto-escaping.

### Changes
- Added `jinja2>=3.1.0` to `requirements.txt` and `setup.py`.
- Created `docksec/templates/report.html.j2` with native loops, conditionals, and auto-escaping.
- Refactored `ReportGenerator.generate_html_report` to use `jinja2.Environment` with `select_autoescape`.
- Removed Python-side HTML generation methods and raw `{{VAR}}` replacements.
- Added comprehensive unit tests in `tests/test_report_generator.py` covering loops, empty states, and auto-escaping.